### PR TITLE
Corrected wring charset

### DIFF
--- a/Documentation/Configuration/Nginx.rst
+++ b/Documentation/Configuration/Nginx.rst
@@ -62,7 +62,7 @@ By the following configuration:
            return 405;
        }
 
-       charset utf8;
+       charset utf-8;
        try_files /typo3temp/tx_staticfilecache/${scheme}/${host}${uri}/index.html
              /typo3temp/tx_staticfilecache/${scheme}/${host}${uri}
              =405;


### PR DESCRIPTION
The encoding utf8 is not the preferred name of the character encoding in use. The preferred name is utf-8.