### PR TITLE
Fix #34 - use local isStaticCacheble check in StaticCacheble rule

### DIFF
--- a/Classes/Cache/Rule/StaticCacheable.php
+++ b/Classes/Cache/Rule/StaticCacheable.php
@@ -23,19 +23,8 @@ class StaticCacheable extends AbstractRule
      */
     public function checkRule(TypoScriptFrontendController $frontendController, string $uri, array &$explanation, bool &$skipProcessing)
     {
-        if (!$this->isStaticCacheble($frontendController)) {
+        if (!$frontendController->isStaticCacheble()) {
             $explanation[__CLASS__] = 'The page is not static chachable via TypoScriptFrontend';
         }
-    }
-
-    /**
-     * Fix this bug: https://forge.typo3.org/issues/83212
-     * @see TypoScriptFrontendController::isStaticCacheble
-     *
-     * @return bool TRUE if caching of current page is enabled (->isUserOrGroupSet() returns false even if no frontend user is logged in!)
-     */
-    public function isStaticCacheble(TypoScriptFrontendController $frontendController)
-    {
-        return !$frontendController->no_cache;
     }
 }

--- a/Classes/Cache/Rule/StaticCacheable.php
+++ b/Classes/Cache/Rule/StaticCacheable.php
@@ -23,8 +23,19 @@ class StaticCacheable extends AbstractRule
      */
     public function checkRule(TypoScriptFrontendController $frontendController, string $uri, array &$explanation, bool &$skipProcessing)
     {
-        if (!$frontendController->isStaticCacheble()) {
+        if (!$this->isStaticCacheble($frontendController)) {
             $explanation[__CLASS__] = 'The page is not static chachable via TypoScriptFrontend';
         }
+    }
+
+    /**
+     * Fix this bug: https://forge.typo3.org/issues/83212
+     * @see TypoScriptFrontendController::isStaticCacheble
+     *
+     * @return bool TRUE if caching of current page is enabled (->isUserOrGroupSet() returns false even if no frontend user is logged in!)
+     */
+    public function isStaticCacheble(TypoScriptFrontendController $frontendController)
+    {
+        return !$frontendController->no_cache;
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,7 +29,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \SFC\Staticfilecache\Command\PublishCommandController::class;
 
 $ruleClasses = [
-    \SFC\Staticfilecache\Cache\Rule\StaticCacheable::class,
+// Ensure functionality until https://forge.typo3.org/issues/83212 is fixed
+//    \SFC\Staticfilecache\Cache\Rule\StaticCacheable::class,
     \SFC\Staticfilecache\Cache\Rule\ValidUri::class,
     \SFC\Staticfilecache\Cache\Rule\ValidDoktype::class,
     \SFC\Staticfilecache\Cache\Rule\NoWorkspacePreview::class,


### PR DESCRIPTION
$frontendController->isStaticCacheable() checks public property "no_cache",  methods isINTincScript() and isUserOrGroupSet(). The last two methods are already checked in Rule\NoIntScripts and Rule\NoUserOrGroupSet. So I added a local isStaticCacheable method to only check for no_cache property.