### PR TITLE
Fix spelling of "cacheable".

### DIFF
--- a/Classes/Cache/Rule/PageCacheable.php
+++ b/Classes/Cache/Rule/PageCacheable.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Check if the current page is static cachable in Page property context.
+ * Check if the current page is static cacheable in Page property context.
  */
 declare(strict_types = 1);
 

--- a/Classes/Cache/Rule/StaticCacheable.php
+++ b/Classes/Cache/Rule/StaticCacheable.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Check if the current page is static cachable in TSFE context.
+ * Check if the current page is static cacheable in TSFE context.
  */
 declare(strict_types = 1);
 
@@ -9,12 +9,12 @@ namespace SFC\Staticfilecache\Cache\Rule;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
- * Check if the current page is static cachable in TSFE context.
+ * Check if the current page is static cacheable in TSFE context.
  */
 class StaticCacheable extends AbstractRule
 {
     /**
-     * Check if the page is static cachable.
+     * Check if the page is static cacheable.
      *
      * Please keep this topic in mind: https://forge.typo3.org/issues/83212
      * EXT:form honeypot uses anonymous FE user, so the caching is disabled
@@ -27,7 +27,7 @@ class StaticCacheable extends AbstractRule
     public function checkRule(TypoScriptFrontendController $frontendController, string $uri, array &$explanation, bool &$skipProcessing)
     {
         if (!$frontendController->isStaticCacheble()) {
-            $explanation[__CLASS__] = 'The page is not static chachable via TypoScriptFrontend';
+            $explanation[__CLASS__] = 'The page is not static cacheable via TypoScriptFrontend';
         }
     }
 }


### PR DESCRIPTION
Short description
-----------------

Correct spelling seems to be "cacheable", see: https://en.wiktionary.org/wiki/cacheable

Also, class names (PageCacheable and StaticCacheable) already have the correct spelling.

Related Issue
-------------

None, I consider it trivial change, but I can create one, if necessary.
