### PR TITLE
[IMPROVEMENT] Duplicate Content is generated

### DIFF
--- a/Documentation/Configuration/Htaccess.rst
+++ b/Documentation/Configuration/Htaccess.rst
@@ -39,7 +39,7 @@ This is the base .htaccess configuration. Please take a look for the default var
    # Check if the requested file exists in the cache, otherwise default to index.html that
    # set in an environment variable that is used later on
    RewriteCond %{ENV:SFC_ROOT}/typo3temp/tx_staticfilecache/%{ENV:SFC_PROTOCOL}/%{ENV:SFC_HOST}%{ENV:SFC_URI} !-f
-   RewriteRule .* - [E=SFC_FILE:/index.html]
+   RewriteRule .* - [E=SFC_FILE:index.html]
 
    ### Begin: Static File Cache (main) ####
 


### PR DESCRIPTION
Static caches are delivered in these both cases: domain.tld/path and domain.tld/path/.

Changing the .htaccess as proposed disables the delivery through domain.tld/path, which can be handled by RealUrl if "appendMissingSlash" is configuired like "ifNotFile,redirect[301]". Otherwise i think a 404 is correct.

What do you think?