### PR TITLE
New signals for compression and cached file removal

### DIFF
--- a/Classes/Cache/Compression/GzipCompression.php
+++ b/Classes/Cache/Compression/GzipCompression.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Abstract Rule.
+ */
+declare(strict_types = 1);
+namespace SFC\Staticfilecache\Cache\Compression;
+
+use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Abstract Rule.
+ */
+class GzipCompression
+{
+
+    /**
+     * The default compression level.
+     */
+    const DEFAULT_COMPRESSION_LEVEL = 3;
+
+    public function compress($fileName, $data)
+    {
+        $gzipFileName = $fileName . '.gz';
+
+        // If file already exists, we assume, that it was already written by another Slot
+        if(!file_exists($gzipFileName)) {
+            $contentGzip = \gzencode($data, $this->getCompressionLevel());
+            if ($contentGzip) {
+                GeneralUtility::writeFile($gzipFileName, $contentGzip);
+            }
+        }
+    }
+
+    /**
+     * Get compression level.
+     *
+     * @return int
+     */
+    protected function getCompressionLevel(): int
+    {
+        $level = self::DEFAULT_COMPRESSION_LEVEL;
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel'])) {
+            $level = (int) $GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel'];
+        }
+        if (!MathUtility::isIntegerInRange($level, 1, 9)) {
+            $level = self::DEFAULT_COMPRESSION_LEVEL;
+        }
+
+        return $level;
+    }
+}

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -25,6 +25,7 @@ use SFC\Staticfilecache\Cache\Rule\ValidRequestMethod;
 use SFC\Staticfilecache\Cache\Rule\ValidUri;
 use SFC\Staticfilecache\Cache\StaticFileBackend;
 use SFC\Staticfilecache\Cache\UriFrontend;
+use SFC\Staticfilecache\Cache\Compression\GzipCompression;
 use SFC\Staticfilecache\Command\CacheCommandController;
 use SFC\Staticfilecache\Command\PublishCommandController;
 use SFC\Staticfilecache\Hook\Cache\ContentPostProcOutput;
@@ -134,6 +135,8 @@ class Configuration
         foreach ($ruleClasses as $class) {
             $signalSlotDispatcher->connect(StaticFileCache::class, 'cacheRule', $class, 'check');
         }
+
+        $signalSlotDispatcher->connect(StaticFileBackend::class, 'compress', GzipCompression::class, 'check');
     }
 
     /**


### PR DESCRIPTION
For our websites we wanted to get better compression. First we wanted to compress the generated gz file further with advancecomp. Additionally we wanted to compress the HTML with brotli. So we introduced a new signal for compression.
This raised a new problem if we were using scheduler tasks to garbage collect the generated files, because only the .html and .gz files were deleted, but not the generated .br files. Because of this, we introduced a new signal to extend the list of files, which would be deleted.
