### PR TITLE
Add scheduler argument: stopProcessingAfter

### DIFF
--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -31,11 +31,12 @@ class CacheCommandController extends AbstractCommandController
      * Run the cache boost queue.
      *
      * @param int $limitItems Limit the items that are crawled. 0 => all
+     * @param int $stopProcessingAfter Stop crawling new items after N seconds since scheduler task started. 0 => infinite
      */
-    public function runCacheBoostQueueCommand($limitItems = 0)
+    public function runCacheBoostQueueCommand($limitItems = 0, $stopProcessingAfter = 0)
     {
         $queue = GeneralUtility::makeInstance(QueueService::class);
-        $queue->run($limitItems);
+        $queue->run($limitItems, $stopProcessingAfter);
     }
 
     /**

--- a/Classes/Service/QueueService.php
+++ b/Classes/Service/QueueService.php
@@ -35,17 +35,23 @@ class QueueService extends AbstractService
      * Run the queue.
      *
      * @param int $limitItems
+     * @param int $stopProcessingAfter
      *
      * @throws \TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException
      */
-    public function run(int $limitItems = 0)
+    public function run(int $limitItems = 0, int $stopProcessingAfter = 0)
     {
         \define('SFC_QUEUE_WORKER', true);
 
+        $startTime = time();
         $limit = $limitItems > 0 ? $limitItems : 999;
         $rows = $this->queueRepository->findOpen($limit);
 
         foreach ($rows as $runEntry) {
+            if ($stopProcessingAfter > 0 && time() >= $startTime + $stopProcessingAfter) {
+                break;
+            }
+
             $this->runSingleRequest($runEntry);
         }
     }


### PR DESCRIPTION
Stop crawling new items after N seconds since scheduler task started.

Short description
-----------------

This adds an optional argument to the command `runCacheBoostQueueCommand`. It complements the already existing argument `limitItems`.

This might come in handy if someone want to stop generating new caches using this function after a fixed time.

Example use-case: "Process up to 250 items in the queue, but do not start processing a new item after 5 minutes of total execution time".

Related Issue
-------------

None

More Details
------------

None

- Work in Progess? No
- Open Issues? No
