### PR TITLE
[FIX] script filename match

### DIFF
--- a/Classes/Service/HttpPush/ScriptHttpPush.php
+++ b/Classes/Service/HttpPush/ScriptHttpPush.php
@@ -34,7 +34,7 @@ class ScriptHttpPush extends AbstractHttpPush
      */
     public function getHeaders(string $content): array
     {
-        preg_match_all('/(?<=["\'])[^="\']*\.js\.*\d*\.*(?:gzi?p?)*(?=["\'])/', $content, $jsFiles);
+        preg_match_all('/(?<=["\'])[^="\']*\.js\.*\d*\.*(?:gzi?p?)[^="\']*(?=["\'])/', $content, $jsFiles);
         $paths = $this->streamlineFilePaths((array)$jsFiles[0]);
         return $this->mapPathsWithType($paths, 'script');
     }


### PR DESCRIPTION
this fix allows matching of urls with query-string of the following filenames: main.js?23444

Short description
-----------------

...

Related Issue
-------------

...

More Details
------------

- Work in Progess?
- Open Issues?
