### PR TITLE
Replace suggest of crawler with seocli

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 		"phpmetrics/phpmetrics": "^2.4"
 	},
 	"suggest": {
-		"aoepeople/crawler": "For crawling the site and warmup the cache",
+		"lochmueller/seocli": "Scan websites against SEO criteria and/or trigger the indexing process and cache warming in deployment scripts",
 		"friendsofsymfony/http-cache": "For HTTP proxy cache services like Varnish"
 	},
 	"config": {


### PR DESCRIPTION
The seocli package is slightly better for crawling websites. It should be suggest instead of the crawler extension.
(e.g. in combination with a CacheCommandController and scheduler, see also #53)