### PR TITLE
[TASK] Allow README.md in composer installations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@
 /.scrutinizer.yml export-ignore
 /.styleci.yml export-ignore
 /.travis.yml export-ignore
-/README.md export-ignore
 /.php_cs export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /.github/ export-ignore


### PR DESCRIPTION
there is no reason to exclude docs in gitattributes. it is very helpful to have the docs offline as well
