### PR TITLE
[BUGFIX] do not try to cache a page which uid could not get discovered

### DIFF
--- a/Classes/StaticFileCache.php
+++ b/Classes/StaticFileCache.php
@@ -77,6 +77,10 @@ class StaticFileCache extends StaticFileCacheObject
      */
     public function insertPageInCache(TypoScriptFrontendController $pObj, int $timeOutTime = 0)
     {
+        if (!$pObj->page['uid']) {
+            return;
+        }
+
         $isStaticCached = false;
 
         $uri = GeneralUtility::makeInstance(UriService::class)->getUri();


### PR DESCRIPTION
Short description
-----------------

If the page was not found the cache-key $table:$uid can not be used and error 500 is generated by TYPO3 caching framework. This fix prevents page from beeing cached, if the ID was not found (404).

More Details
------------

TYPO3 Version	9.5.7
Webserver	nginx/1.10.3
PHP Version	7.3.5
Database (Default)	MySQL 5.7.24
