### PR TITLE
avoid tinytext and use an index on the cache url

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -13,11 +13,12 @@ CREATE TABLE pages (
 #
 CREATE TABLE tx_staticfilecache_queue (
 	uid int(11) NOT NULL auto_increment,
-	cache_url tinytext NOT NULL,
+	cache_url varchar(500) NOT NULL,
 	cache_priority int(11) DEFAULT '0' NOT NULL,
 	page_uid int(11) DEFAULT '0' NOT NULL,
 	invalid_date int(11) DEFAULT '0' NOT NULL,
 	call_date int(11) DEFAULT '0' NOT NULL,
-	call_result tinytext NOT NULL,
-	PRIMARY KEY (uid)
+	call_result varchar(255) NOT NULL,
+	PRIMARY KEY (uid),
+	INDEX call_date (call_date, cache_url)
 );


### PR DESCRIPTION
Clearing the cache will create a lot of boost queue entries
and creating a boost queue entry requires checking if it is already
present.

The fields required for that query were previously not indexed.

This change speeds up cache clears with boost mode dramatically.