### PR TITLE
Set key-length for cache_url on boost-queue table

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -20,5 +20,5 @@ CREATE TABLE tx_staticfilecache_queue (
 	call_date int(11) DEFAULT '0' NOT NULL,
 	call_result varchar(255) NOT NULL,
 	PRIMARY KEY (uid),
-	INDEX call_date (call_date, cache_url)
+	INDEX call_date (call_date, cache_url(100))
 );


### PR DESCRIPTION
To avoid a warning during database-migration, the key-length is explicitly set


Related Issue
-------------

https://typo3.slack.com/archives/C9LRD4LSJ/p1573750733017800
