### PR TITLE
Ignore Yoast SEO requests

### DIFF
--- a/Classes/Cache/Rule/NoFakeFrontend.php
+++ b/Classes/Cache/Rule/NoFakeFrontend.php
@@ -36,10 +36,16 @@ class NoFakeFrontend extends AbstractRule
             foreach ($this->getCallPaths() as $path) {
                 if (StringUtility::endsWith($path, $ignorePath)) {
                     $skipProcessing = true;
+                    $explanation[__CLASS__] = 'Fake frontend';
 
                     return;
                 }
             }
+        }
+
+        if ($request->hasHeader('x-yoast-page-request')) {
+            $skipProcessing = true;
+            $explanation[__CLASS__] = 'Yoast SEO page request';
         }
     }
 


### PR DESCRIPTION
Short description
-----------------

Yoast SEO provides a feature called "Snippet Preview" which leads to cache poisoning if the requests aren't ignored.

Related Issue
-------------

https://github.com/lochmueller/staticfilecache/issues/222
