### PR TITLE
[FIX] move PrepareMiddleware after SiteMiddleware

### DIFF
--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -5,19 +5,16 @@ return [
         'staticfilecache/prepare' => [
             'target' => \SFC\Staticfilecache\Middleware\PrepareMiddleware::class,
             'before' => [
-                'typo3/cms-frontend/tsfe',
+                'typo3/cms-frontend/base-redirect-resolver',
             ],
             'after' => [
-                'typo3/cms-frontend/eid',
+                'typo3/cms-frontend/site',
             ],
         ],
         'staticfilecache/generate' => [
             'target' => \SFC\Staticfilecache\Middleware\GenerateMiddleware::class,
             'before' => [
                 'staticfilecache/prepare',
-            ],
-            'after' => [
-                'typo3/cms-frontend/eid',
             ],
         ],
         'staticfilecache/fallback' => [


### PR DESCRIPTION
SiteCacheable rule needs already loaded Site configuration

Short description
-----------------
![image](https://user-images.githubusercontent.com/3999104/69347861-875dcd80-0c75-11ea-8989-651189bb3d05.png)
...

Related Issue
-------------
None
...

More Details
------------

- Work in Progress? No
- Open Issues? No
