### PR TITLE
[BUGFIX] Fix typo in backend module

### DIFF
--- a/Resources/Private/Templates/Backend/Boost.html
+++ b/Resources/Private/Templates/Backend/Boost.html
@@ -12,7 +12,7 @@
 				Nice... you use the boost mode. <strong>BAM!</strong>.<br/>
 				Please take care that the scheduler/cron task that work on the queue is running.
 			</p>
-			<div class="alert alert-notice" role="alert">There are <strong>{open}</strong> items that ways for processing and <strong>{old}</strong> old items.</div>
+			<div class="alert alert-notice" role="alert">There are <strong>{open}</strong> items that wait for processing and <strong>{old}</strong> old items.</div>
 
 			<f:link.action action="boost" class="btn btn-default" arguments="{run: 1}">
 				<core:icon identifier="actions-system-refresh"/>


### PR DESCRIPTION
Short description
-----------------

There was a strange wording in the backend module. 

> There are 7154 items that **ways** for processing and 46 old items.

I changed it to

> There are 7154 items that **wait** for processing and 46 old items.

Of course, I did not change the formatting. The bold formatting here is only to mark the change.

Related Issue
-------------

none

More Details
------------

none