### PR TITLE
[BUGFIX] Support TYPO3 v10 HTTP handler stack

### DIFF
--- a/Classes/Service/ClientService.php
+++ b/Classes/Service/ClientService.php
@@ -11,6 +11,7 @@ namespace SFC\Staticfilecache\Service;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;
+use GuzzleHttp\HandlerStack;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
@@ -77,6 +78,13 @@ class ClientService extends AbstractService
         // Core options
         $httpOptions = (array)$GLOBALS['TYPO3_CONF_VARS']['HTTP'];
         $httpOptions['verify'] = filter_var($httpOptions['verify'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $httpOptions['verify'];
+        if (isset($httpOptions['handler']) && is_array($httpOptions['handler'])) {
+            $stack = HandlerStack::create();
+            foreach ($httpOptions['handler'] ?? [] as $handler) {
+                $stack->push($handler);
+            }
+            $httpOptions['handler'] = $stack;
+        }
 
         // extended
         $params = [


### PR DESCRIPTION
Short description
-------------


An empty `handler` array in TYPO3_CONF_VARS.HTTP was introduced in
https://review.typo3.org/c/Packages/TYPO3.CMS/+/61407
When an empty `handle` array is passed to the guzzle client,
an exception is thrown as guzzle expects `handler`
to be callable or unset.

```
[ERROR] request="…"  component="SFC.Staticfilecache.Service.ClientService": Problems in single request running: handler must be a callable / …/typo3_src-10.4.0/vendor/guzzlehttp/guzzle/src/Client.php:67
```

TYPO3 core initializes an handler stack from the handler
array. For compatibility reasons the staticfilecache
should do so as well.



Related Issue
-------------

#251 