### PR TITLE
Force proper cache file MIME Type via .htaccess

### DIFF
--- a/Resources/Private/Templates/Htaccess.html
+++ b/Resources/Private/Templates/Htaccess.html
@@ -1,4 +1,5 @@
 {escaping off}
+ForceType {contentType}
 <f:if condition="{sendCacheControlHeader}">
 <IfModule mod_expires.c>
 	ExpiresActive on


### PR DESCRIPTION
Short description
-----------------
This adds a ForceType directive to the .htaccess template, to make sure that Apache applies the correct cache headers configured by ModExpires.

In addition this also makes sure that Apache sends the proper Content-Type header, if ModHeaders is not available or the Content-Type header is not whitelisted for inclusion in the .htaccess.

See #258 for detailed information on why this fix is needed.

Related Issue
-------------
* Fixes #258
* (Probably Fixes) #253

More Details
------------
This change also obsoletes a lot of the `FilesMatch` directives in the main `.htaccess` file in the TYPO3 document root, but they do not conflict and removal should be discussed in a separate issue / PR.
