### PR TITLE
Possibility for http2 push area (head or body) restrictions

### DIFF
--- a/Classes/Service/HttpPushService.php
+++ b/Classes/Service/HttpPushService.php
@@ -30,7 +30,17 @@ class HttpPushService extends AbstractService
         $configurationService = GeneralUtility::makeInstance(ConfigurationService::class);
         if ($configurationService->isBool('sendHttp2PushEnable')) {
             $limit = (int)$configurationService->get('sendHttp2PushFileLimit');
+            $limitToArea = $configurationService->get('sendHttp2PushLimitToArea');
             $extensions = GeneralUtility::trimExplode(',', (string)$configurationService->get('sendHttp2PushFileExtensions'), true);
+
+            $limitToAreaMatches = [];
+            if ($limitToArea === 'head') {
+                \preg_match_all('/<head[^>]*>.*<\/head>/s', $content, $limitToAreaMatches);
+                $content = (string)$limitToAreaMatches[0][0];
+            } elseif ($limitToArea === 'body') {
+                \preg_match_all('/<body[^>]*>.*<\/body>/s', $content, $limitToAreaMatches);
+                $content = (string)$limitToAreaMatches[0][0];
+            }
 
             foreach (GeneralUtility::makeInstance(ObjectFactoryService::class)->get('HttpPush') as $handler) {
                 foreach ($extensions as $extension) {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -63,3 +63,6 @@ sendHttp2PushFileExtensions = css,js
 
 # cat=HttpPush; type=string; label=File limit for HTTP/2 push: The limit of files that are added as HTTP/2 push
 sendHttp2PushFileLimit = 10
+
+# cat=HttpPush; type=options[No Limit=,<head> tag=head,<body> tag=body]; label=Limit the pushes to specific areas: You can select from either '<head>' or '<body>', which pushes only the assets from the named area. Otherwise, and as default, the whole '<html>' tag is taken.
+sendHttp2PushLimitToArea =


### PR DESCRIPTION
Short description
-----------------

Add a possibility to select an area (head, body or complete html) to limit the http2 pushes to the resources found there.
If not set, the whole '<html>' tag is taken (as before).

I need this for a project of mine, maybe this could be useful also for others...

Related Issue
-------------

no open issue
