### PR TITLE
[FIX] do not remove double-quotes - just escape them

### DIFF
--- a/Classes/Generator/HtaccessGenerator.php
+++ b/Classes/Generator/HtaccessGenerator.php
@@ -45,7 +45,7 @@ class HtaccessGenerator extends AbstractGenerator
         }
 
         $headers = array_map(function ($item) {
-            return str_replace('"', '', $item);
+            return str_replace('"', '\"', $item);
         }, $headers);
 
         $sendCacheControlHeader = isset($GLOBALS['TSFE']->config['config']['sendCacheHeaders']) ? (bool) $GLOBALS['TSFE']->config['config']['sendCacheHeaders'] : false;


### PR DESCRIPTION
works in apache 2.4.38. Can't verify on other versions.

Short description
-----------------

...

Related Issue
-------------

...

More Details
------------

- Work in Progress?
- Open Issues?
