### PR TITLE
Rename cache prefix from cf_ to cache_

### DIFF
--- a/Documentation/KnownProblems/Index.rst
+++ b/Documentation/KnownProblems/Index.rst
@@ -52,10 +52,10 @@ Clear all caches for editors
 
 The possibility to clear all caches is not very useful for regular editor, because they do not understand what exactly means "clear all caches". So it is recommended to use the PageTSConfig option "options.clearCache.pages" to prevent a system wide clear cache mechanism for editors. Ask the editor "why" they use the "clear all cache" and use cache tags, cache groups and clear cache hooks to create the right situation without clearing all caches.
 
-Hard remove of cf_* tables
---------------------------
+Hard remove of cache_* tables
+-----------------------------
 
-There are mechanisms (e.g. typo3_console clear cache force) that a truncate the cf_* tables directly. In this case the StaticFileCache is not in sync anymore (the DB and file layer).
+There are mechanisms (e.g. typo3_console clear cache force) that truncate the cache_* tables directly. In this case the StaticFileCache is not in sync anymore (the DB and file layer).
 If you are using such mechanism, please use the "renameTablesToOtherPrefix" configuration that the caching tables of the StaticFileCache get another prefix.
 
 Using Garbage Collection

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -16,7 +16,7 @@ validHtaccessHeaders = Content-Type,Content-Language,Link,X-SFC-Tags
 # cat=basic; type=boolean; label=Disable StaticFileCache in development: When checked, the StaticFileCache won't be generated if in development application context.
 disableInDevelopment = 0
 
-# cat=basic; type=boolean; label=Rename caching tables from cf_* to sfc_*: When checked, the caching tables of the DB layer are not prefixed with cf_* anymore. If you truncate the cf_* tables (typo3_console clear cache force) without the implementation, the cache has files but no DB representation. You could rename the tables with this options (run DB compare!!)
+# cat=basic; type=boolean; label=Rename caching tables from cache_* to sfc_*: When checked, the caching tables of the DB layer are not prefixed with cache_* anymore. If you truncate the cache_* tables (typo3_console clear cache force) without the implementation, the cache has files but no DB representation. You could rename the tables with this options (run DB compare!!)
 renameTablesToOtherPrefix = 0
 
 # cat=basic; type=boolean; label=Use reverse URI length in priority: Add "1000-URILENGTH" to the priority so the home page is much more important than deeplinks


### PR DESCRIPTION
In the supported versions of TYPO3 the cache tables are prefixed
with cache_ and not with cf_ anymore.