### PR TITLE
Bugfix/11.1.7 hashed identifiers

### DIFF
--- a/Classes/Cache/StaticFileBackend.php
+++ b/Classes/Cache/StaticFileBackend.php
@@ -302,7 +302,7 @@ class StaticFileBackend extends StaticDatabaseBackend implements TransientBacken
                 return '';
             }
             $entry = unserialize($data);
-            $url = $entry['url'];
+            $url = $entry['url'] ?? '';
         }
         $identifierBuilder = GeneralUtility::makeInstance(IdentifierBuilder::class);
         return $identifierBuilder->getFilepath($url);

--- a/Classes/Cache/StaticFileBackend.php
+++ b/Classes/Cache/StaticFileBackend.php
@@ -302,7 +302,9 @@ class StaticFileBackend extends StaticDatabaseBackend implements TransientBacken
                 return '';
             }
             $entry = unserialize($data);
-            $url = $entry['url'] ?? '';
+            if (!empty($entry['url'])) {
+                $url = $entry['url'];
+            }
         }
         $identifierBuilder = GeneralUtility::makeInstance(IdentifierBuilder::class);
         return $identifierBuilder->getFilepath($url);


### PR DESCRIPTION
Short description
-----------------

Should solve
Return value of SFC\Staticfilecache\Cache\StaticFileBackend::getFilepath() must be of the type string, null returned

