### PR TITLE
Add command description to Services.yaml

### DIFF
--- a/Classes/Command/BoostQueueCommand.php
+++ b/Classes/Command/BoostQueueCommand.php
@@ -33,7 +33,7 @@ class BoostQueueCommand extends AbstractCommand
     {
         $this->queueRepository = $queueRepository;
         $this->queueService = $queueService;
-        parent::__construct('staticfilecache:boostQueue');
+        parent::__construct();
     }
 
     /**
@@ -42,6 +42,7 @@ class BoostQueueCommand extends AbstractCommand
     protected function configure(): void
     {
         parent::configure();
+        // @todo When compatibility is set to TYPO3 v11+ only, the description can be removed as it is defined in Services.yaml
         $this->setDescription('Run (work on) the cache boost queue. Call this task every 5 minutes.')
             ->addOption('limit-items', null, InputOption::VALUE_REQUIRED, 'Limit the items that are crawled. 0 => all', 500)
             ->addOption('stop-processing-after', null, InputOption::VALUE_REQUIRED, 'Stop crawling new items after N seconds since scheduler task started. 0 => infinite', 240)

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,6 +10,7 @@ services:
   SFC\Staticfilecache\Command\BoostQueueCommand:
     tags:
       - name: 'console.command'
+        description: 'Run (work on) the cache boost queue. Call this task every 5 minutes.'
         command: 'staticfilecache:boostQueue'
 
   SFC\Staticfilecache\EventListener\AfterPackageDeactivationListener:


### PR DESCRIPTION
For TYPO3 v11 the description must be defined in the Configuration/Services.yaml
to be shown in the command list. The setting of the description in the configure 
method of the command is kept for TYPO3 v10 and can be removed when 
compatibility for v10 is removed.

See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/11.1/Feature-93174-LazyConsoleCommandList.html

Additionally, the superfluous argument when calling the parent constructor
is also removed at it is defined in Services.yaml.