### PR TITLE
Consider new session handling for TYPO3 v11

### DIFF
--- a/Classes/Hook/LogoffFrontendUser.php
+++ b/Classes/Hook/LogoffFrontendUser.php
@@ -10,6 +10,7 @@ namespace SFC\Staticfilecache\Hook;
 
 use SFC\Staticfilecache\Service\CookieService;
 use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -25,7 +26,7 @@ class LogoffFrontendUser extends AbstractHook
     public function logoff($parameters, AbstractUserAuthentication $parentObject): void
     {
         $service = GeneralUtility::makeInstance(CookieService::class);
-        if (('FE' === $parentObject->loginType || 'BE' === $parentObject->loginType) && true === $parentObject->newSessionID) {
+        if (('FE' === $parentObject->loginType || 'BE' === $parentObject->loginType) && $this->isNewSession($parentObject)) {
             $formData = $parentObject->getLoginFormData();
             if ('logout' !== $formData['status']) {
                 $service->setCookie(time() + 3600);
@@ -34,5 +35,14 @@ class LogoffFrontendUser extends AbstractHook
             }
         }
         $service->unsetCookie();
+    }
+
+    private function isNewSession(AbstractUserAuthentication $parentObject): bool
+    {
+        if ((new Typo3Version())->getMajorVersion() === 10) {
+            return true === $parentObject->newSessionID;
+        }
+
+        return $parentObject->getSession()->isNew();
     }
 }


### PR DESCRIPTION
The property AbstractUserAuthentication::newSessionID was removed with TYPO3 v11.0.
This patch restores the functionality of the hook for TYPO3 v11 and also avoids
the warning "Undefined property: TYPO3\CMS\Core\Authentication\BackendUserAuthentication::$newSessionID"
on PHP 8.0.

See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/11.0/Breaking-93023-ReworkedSessionHandling.html