### PR TITLE
Fix "Undefined array key" warning on PHP8

### DIFF
--- a/Classes/Cache/Listener/StaticCacheableListener.php
+++ b/Classes/Cache/Listener/StaticCacheableListener.php
@@ -19,7 +19,7 @@ class StaticCacheableListener
      */
     public function __invoke(CacheRuleEvent $event): void
     {
-        if (\is_object($GLOBALS['TSFE']) && !$GLOBALS['TSFE']->isStaticCacheble()) {
+        if (\is_object($GLOBALS['TSFE'] ?? null) && !$GLOBALS['TSFE']->isStaticCacheble()) {
             $event->addExplanation(__CLASS__, 'The page is not static cacheable via TypoScriptFrontend. Check the first Question on: https://github.com/lochmueller/staticfilecache/blob/master/Documentation/Faq/Index.rst');
         }
     }

--- a/Classes/Cache/Rule/LoginDeniedConfiguration.php
+++ b/Classes/Cache/Rule/LoginDeniedConfiguration.php
@@ -20,11 +20,11 @@ class LoginDeniedConfiguration extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if (!\is_object($GLOBALS['TSFE'])) {
+        if (!\is_object($GLOBALS['TSFE'] ?? null)) {
             return;
         }
         $name = 'sendCacheHeaders_onlyWhenLoginDeniedInBranch';
-        $loginDeniedCfg = (!$GLOBALS['TSFE']->config['config'][$name] || !$GLOBALS['TSFE']->checkIfLoginAllowedInBranch());
+        $loginDeniedCfg = (!($GLOBALS['TSFE']->config['config'][$name] ?? false) || !$GLOBALS['TSFE']->checkIfLoginAllowedInBranch());
         if (!$loginDeniedCfg) {
             $explanation[__CLASS__] = 'LoginDeniedCfg is true';
         }

--- a/Classes/Cache/Rule/NoIntScripts.php
+++ b/Classes/Cache/Rule/NoIntScripts.php
@@ -20,7 +20,7 @@ class NoIntScripts extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if (\is_object($GLOBALS['TSFE']) && $GLOBALS['TSFE']->isINTincScript()) {
+        if (\is_object($GLOBALS['TSFE'] ?? null) && $GLOBALS['TSFE']->isINTincScript()) {
             foreach ((array) $GLOBALS['TSFE']->config['INTincScript'] as $key => $configuration) {
                 $explanation[__CLASS__.':'.$key] = 'The page has a INTincScript: '.implode(', ', $this->getInformation($configuration));
             }

--- a/Classes/Cache/Rule/NoWorkspacePreview.php
+++ b/Classes/Cache/Rule/NoWorkspacePreview.php
@@ -20,7 +20,7 @@ class NoWorkspacePreview extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if (\is_object($GLOBALS['TSFE']) && $GLOBALS['TSFE']->doWorkspacePreview()) {
+        if (\is_object($GLOBALS['TSFE'] ?? null) && $GLOBALS['TSFE']->doWorkspacePreview()) {
             $explanation[__CLASS__] = 'The page is in workspace preview mode';
         }
     }


### PR DESCRIPTION
This patch fixes the PHP Warning: Undefined array key "sendCacheHeaders_onlyWhenLoginDeniedInBranch" in /var/www/html/public/typo3conf/ext/staticfilecache/Classes/Cache/Rule/LoginDeniedConfiguration.php line 27

Additionally, the usages of $GLOBALS['TSFE'] are also revised and a fallback implemented.