### PR TITLE
Prevent Exception for unaccessible property (Fixes #313)

### DIFF
--- a/Classes/Middleware/GenerateMiddleware.php
+++ b/Classes/Middleware/GenerateMiddleware.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class GenerateMiddleware implements MiddlewareInterface
 {
-    protected UriFrontend ?$cache = null;
+    protected ?UriFrontend $cache = null;
 
     protected EventDispatcherInterface $eventDispatcher;
 

--- a/Classes/Middleware/GenerateMiddleware.php
+++ b/Classes/Middleware/GenerateMiddleware.php
@@ -27,7 +27,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class GenerateMiddleware implements MiddlewareInterface
 {
-    protected UriFrontend $cache;
+    protected UriFrontend ?$cache = null;
 
     protected EventDispatcherInterface $eventDispatcher;
 


### PR DESCRIPTION
This happens while Reflection API is used to observe this class, e.g. with `<f:debug/>` 