### PR TITLE
Related lochmueller#321 Fix PHP 8 warning in even more places

### DIFF
--- a/Classes/Cache/Rule/LoginDeniedConfiguration.php
+++ b/Classes/Cache/Rule/LoginDeniedConfiguration.php
@@ -21,11 +21,12 @@ class LoginDeniedConfiguration extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if (!($GLOBALS['TSFE'] instanceof TypoScriptFrontendController)) {
+		$tsfe = $GLOBALS['TSFE'] ?? null;
+        if (!($tsfe instanceof TypoScriptFrontendController)) {
             return;
         }
         $name = 'sendCacheHeaders_onlyWhenLoginDeniedInBranch';
-        $loginDeniedCfg = (!($GLOBALS['TSFE']->config['config'][$name] ?? false) || !$GLOBALS['TSFE']->checkIfLoginAllowedInBranch());
+        $loginDeniedCfg = (!($tsfe->config['config'][$name] ?? false) || !$tsfe->checkIfLoginAllowedInBranch());
         if (!$loginDeniedCfg) {
             $explanation[__CLASS__] = 'LoginDeniedCfg is true';
         }

--- a/Classes/Cache/Rule/NoIntScripts.php
+++ b/Classes/Cache/Rule/NoIntScripts.php
@@ -21,8 +21,9 @@ class NoIntScripts extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController && $GLOBALS['TSFE']->isINTincScript()) {
-            foreach ((array) $GLOBALS['TSFE']->config['INTincScript'] as $key => $configuration) {
+		$tsfe = $GLOBALS['TSFE'] ?? null;
+        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->isINTincScript()) {
+            foreach ((array) $tsfe->config['INTincScript'] as $key => $configuration) {
                 $explanation[__CLASS__.':'.$key] = 'The page has a INTincScript: '.implode(', ', $this->getInformation($configuration));
             }
         }

--- a/Classes/Cache/Rule/NoNoCache.php
+++ b/Classes/Cache/Rule/NoNoCache.php
@@ -21,7 +21,8 @@ class NoNoCache extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController && $GLOBALS['TSFE']->no_cache) {
+		$tsfe = $GLOBALS['TSFE'] ?? null;
+        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->no_cache) {
             $explanation[__CLASS__] = 'config.no_cache is true';
         }
     }

--- a/Classes/Cache/Rule/ValidDoktype.php
+++ b/Classes/Cache/Rule/ValidDoktype.php
@@ -20,7 +20,8 @@ class ValidDoktype extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if (!isset($GLOBALS['TSFE']->page)) {
+		$tsfe = $GLOBALS['TSFE'] ?? null;
+        if (!($tsfe instanceof TypoScriptFrontendController) || !isset($GLOBALS['TSFE']->page)) {
             $explanation[__CLASS__] = 'There is no valid page in the frontendController object';
             $skipProcessing = true;
 

--- a/Classes/Cache/Rule/ValidPageInformation.php
+++ b/Classes/Cache/Rule/ValidPageInformation.php
@@ -23,7 +23,8 @@ class ValidPageInformation extends AbstractRule
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        if (!$GLOBALS['TSFE'] instanceof TypoScriptFrontendController || !\is_array($GLOBALS['TSFE']->page) || !$GLOBALS['TSFE']->page['uid']) {
+		$tsfe = $GLOBALS['TSFE'] ?? null;
+        if (!$tsfe instanceof TypoScriptFrontendController || !\is_array($tsfe->page) || !$tsfe->page['uid']) {
             $skipProcessing = true;
             $explanation[__CLASS__] = 'There is no valid page in the TSFE';
         }


### PR DESCRIPTION
Short description
-----------------
This pull request fixes the mentioned Undefined array key warning in five more cache rule classes.

Related Issue
-------------
lochmueller#321