### PR TITLE
Replace "StringUtility::endsWith" with "str_ends_with"

### DIFF
--- a/Classes/Cache/Rule/NoFakeFrontend.php
+++ b/Classes/Cache/Rule/NoFakeFrontend.php
@@ -28,7 +28,7 @@ class NoFakeFrontend extends AbstractRule
         ];
         foreach ($ignorePaths as $ignorePath) {
             foreach ($this->getCallPaths() as $path) {
-                if (StringUtility::endsWith($path, $ignorePath)) {
+                if (str_ends_with($path, $ignorePath)) {
                     $skipProcessing = true;
                     $explanation[__CLASS__] = 'Fake frontend';
 


### PR DESCRIPTION
Due to the deprecation https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95293-StringUtilitystartsWithAndStringUtilityendsWith.html in Typo3 v11.5, it would be good to replace "StringUtility::endsWith" with the *native* "str_ends_with" function. 

Even if this is a PHP 8.0 function, since Typo3 v10.4.21 and v11.5.2 there is the polyfill "symfony/polyfill-php80" installed automatically. 
Means we can use it without filling up the deprecation log.

Maybe its would be good to raise the dependencies (^10.4.21 || ^11.5.2) in composer.json as well...