### PR TITLE
Replace deprecated "GeneralUtility::shortMD5" function

### DIFF
--- a/Classes/Cache/RemoteFileBackend.php
+++ b/Classes/Cache/RemoteFileBackend.php
@@ -326,7 +326,7 @@ class RemoteFileBackend extends AbstractBackend implements TaggableBackendInterf
         }
 
         // Hash
-        $hash = (string) GeneralUtility::shortMD5($entryIdentifier, $this->hashLength);
+        $hash = substr(md5($entryIdentifier), 0, $this->hashLength);
         $remoteStructure = implode('/', str_split($hash));
 
         return $remoteStructure.'/'.$baseName;


### PR DESCRIPTION
As of https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94684-GeneralUtilityShortMD5.html the Utility "GeneralUtility::shortMD5" has been deprecated and will be replaced with the native counterpart.