### PR TITLE
Update nginx example configuration for indexing via EXT:solr

### DIFF
--- a/Documentation/Configuration/Nginx.rst
+++ b/Documentation/Configuration/Nginx.rst
@@ -53,12 +53,18 @@ By the following configuration:
        if ($cookie_staticfilecache = 'typo_user_logged_in') {
            return 405;
        }
+
        if ($cookie_be_typo_user != '') {
            return 405;
        }
 
        # Ensure we redirect to TYPO3 for non GET/HEAD requests
        if ($request_method !~ ^(GET|HEAD)$ ) {
+           return 405;
+       }
+
+       # Disable cache for EXT:solr indexing requests
+       if ($http_x_tx_solr_iq) {
            return 405;
        }
 


### PR DESCRIPTION
Short description
-----------------

Example for NGINX like the one already provided for Apache via .htaccess within Htaccess.rst

Related Issue
-------------

None

More Details
------------

If EXT:solr and EXT:staticfilecache are in use, indexing request cause errors if cache is used as described in #200 
