### PR TITLE
[CLEANUP] comment/declare order & TYPO3_MODE checks

### DIFF
--- a/Classes/Command/BoostQueueCommand.php
+++ b/Classes/Command/BoostQueueCommand.php
@@ -3,6 +3,7 @@
 /**
  * BoostQueueRunCommand.
  */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Command;

--- a/Classes/Command/FlushCacheCommand.php
+++ b/Classes/Command/FlushCacheCommand.php
@@ -3,6 +3,7 @@
 /**
  * FlushCacheCommand.
  */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Command;

--- a/Classes/EventListener/AfterPackageDeactivationListener.php
+++ b/Classes/EventListener/AfterPackageDeactivationListener.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * AfterPackageDeactivationListener.
+ */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\EventListener;

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * Exception.
+ */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache;

--- a/Classes/Hook/DatamapHook.php
+++ b/Classes/Hook/DatamapHook.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * DatamapHook.
  */
+
+declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Hook;
 

--- a/Classes/Service/DateTimeService.php
+++ b/Classes/Service/DateTimeService.php
@@ -3,6 +3,7 @@
 /**
  * DateTimeService.
  */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Service;

--- a/Classes/Service/EnvironmentService.php
+++ b/Classes/Service/EnvironmentService.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * EnvironmentService.
  */
+
+declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Service;
 

--- a/Classes/Service/GeneratorService.php
+++ b/Classes/Service/GeneratorService.php
@@ -3,6 +3,7 @@
 /**
  * GeneratorService.
  */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Service;

--- a/Classes/Service/HttpPush/AbstractHttpPush.php
+++ b/Classes/Service/HttpPush/AbstractHttpPush.php
@@ -3,6 +3,7 @@
 /**
  * AbstractHttpPush.
  */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Service\HttpPush;

--- a/Classes/Service/HttpPush/SvgHttpPush.php
+++ b/Classes/Service/HttpPush/SvgHttpPush.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * SvgHttpPush.
+ */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Service\HttpPush;

--- a/Classes/Service/InlineAssetsService.php
+++ b/Classes/Service/InlineAssetsService.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * InlineAssetsService.
+ */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Service;

--- a/Classes/StaticFileCacheObject.php
+++ b/Classes/StaticFileCacheObject.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Generic object for Static File Cache incl. Logging.
  */
+
+declare(strict_types=1);
 
 namespace SFC\Staticfilecache;
 

--- a/Classes/Traits/CacheTrait.php
+++ b/Classes/Traits/CacheTrait.php
@@ -3,6 +3,7 @@
 /**
  * Caching Trait.
  */
+
 declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Traits;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,7 +1,3 @@
-<?php
-
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
-}
+<?php defined('TYPO3_MODE') || die();
 
 \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\SFC\Staticfilecache\Configuration::class)->extLocalconf();

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,7 +1,3 @@
-<?php
-
-if (!defined('TYPO3_MODE')) {
-    die('Access denied.');
-}
+<?php defined('TYPO3_MODE') || die();
 
 \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\SFC\Staticfilecache\Configuration::class)->extTables();


### PR DESCRIPTION
btw/ most of the "comments" are written twice within the same file ; intentional?
ref. https://github.com/lochmueller/staticfilecache/blob/master/Classes/StaticFileCacheObject.php