### PR TITLE
Implement middleware to validate cookie

### DIFF
--- a/Classes/Hook/LogoffFrontendUser.php
+++ b/Classes/Hook/LogoffFrontendUser.php
@@ -25,7 +25,7 @@ class LogoffFrontendUser extends AbstractHook
         if (('FE' === $parentObject->loginType || 'BE' === $parentObject->loginType) && $this->isNewSession($parentObject)) {
             $formData = $parentObject->getLoginFormData();
             if ('logout' !== $formData['status']) {
-                $service->setCookie(time() + 3600);
+                $service->setCookie(0);
 
                 return;
             }

--- a/Classes/Middleware/CookieCheckMiddleware.php
+++ b/Classes/Middleware/CookieCheckMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SFC\Staticfilecache\Middleware;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use SFC\Staticfilecache\Service\CookieService;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * CookieCheckMiddleware.
+ */
+class CookieCheckMiddleware implements MiddlewareInterface
+{
+    protected Context $context;
+    protected CookieService $cookieService;
+    protected EventDispatcherInterface $eventDispatcher;
+
+    /**
+     * CookieCheckMiddleware constructor.
+     */
+    public function __construct(Context $context, CookieService $cookieService, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->context = $context;
+        $this->cookieService = $cookieService;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Check for the sfc cookie and remove it when there is no valid user session.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->cookieService->hasCookie() && !$this->context->getAspect('frontend.user')->isLoggedIn() && !$this->context->getAspect('backend.user')->isLoggedIn()) {
+            // Remove staticfilecache cookie when no backend or frontend user is logged in
+            $this->cookieService->unsetCookie();
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/Classes/Middleware/FrontendUserMiddleware.php
+++ b/Classes/Middleware/FrontendUserMiddleware.php
@@ -36,7 +36,7 @@ class FrontendUserMiddleware implements MiddlewareInterface
             // If new session and the cookie is a sessioncookie, we need to set it only once!
             // // isSetSessionCookie()
             $cookieService->setCookie(0);
-        } elseif (($started || isset($_COOKIE[CookieService::FE_COOKIE_NAME])) && $feUser->lifetime > 0) {
+        } elseif (($started || $cookieService->hasCookie()) && $feUser->lifetime > 0) {
             // If it is NOT a session-cookie, we need to refresh it.
             // isRefreshTimeBasedCookie()
             $cookieService->setCookie((new DateTimeService())->getCurrentTime() + $feUser->lifetime);

--- a/Classes/Middleware/GenerateMiddleware.php
+++ b/Classes/Middleware/GenerateMiddleware.php
@@ -27,12 +27,15 @@ class GenerateMiddleware implements MiddlewareInterface
 
     protected EventDispatcherInterface $eventDispatcher;
 
+    protected CookieService $cookieService;
+
     /**
      * GenerateMiddleware constructor.
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct(EventDispatcherInterface $eventDispatcher, CookieService $cookieService)
     {
         $this->eventDispatcher = $eventDispatcher;
+        $this->cookieService = $cookieService;
     }
 
     /**
@@ -65,7 +68,7 @@ class GenerateMiddleware implements MiddlewareInterface
         $uri = $event->getUri();
         $response = $event->getResponse();
         if (!$response->hasHeader('X-SFC-Explanation')) {
-            if ($this->hasValidCacheEntry($uri) && !isset($_COOKIE[CookieService::FE_COOKIE_NAME])) {
+            if ($this->hasValidCacheEntry($uri) && !$this->cookieService->hasCookie()) {
                 $response = $response->withHeader('X-SFC-State', 'TYPO3 - already in cache');
 
                 return $this->removeSfcHeaders($response);

--- a/Classes/Service/CookieService.php
+++ b/Classes/Service/CookieService.php
@@ -18,8 +18,6 @@ class CookieService extends AbstractService
 
     /**
      * Set the Cookie.
-     *
-     * @param $lifetime
      */
     public function setCookie(int $lifetime): void
     {
@@ -32,6 +30,11 @@ class CookieService extends AbstractService
     public function unsetCookie(): void
     {
         $this->setCookie(time() - 3600);
+    }
+
+    public function hasCookie(): bool
+    {
+        return isset($_COOKIE[self::FE_COOKIE_NAME]);
     }
 
     /**

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,5 +1,6 @@
 <?php
 
+use SFC\Staticfilecache\Middleware\CookieCheckMiddleware;
 use SFC\Staticfilecache\Middleware\FallbackMiddleware;
 use SFC\Staticfilecache\Middleware\FrontendUserMiddleware;
 use SFC\Staticfilecache\Middleware\GenerateMiddleware;
@@ -35,6 +36,15 @@ return [
             ],
             'before' => [
                 'staticfilecache/generate',
+            ],
+        ],
+        'staticfilecache/cookie-check' => [
+            'target' => CookieCheckMiddleware::class,
+            'before' => [
+                'staticfilecache/generate',
+            ],
+            'after' => [
+                'staticfilecache/frontend-user',
             ],
         ],
     ],


### PR DESCRIPTION
Short description
-----------------

Raised the cookie lifetime for Backend Logins to the end of the browser session like the TYPO3 fe/be user cookies.

Implemented new Middleware "CookieCheck" to validate the staticfilecache cookie against frontend and backend user sessions. If no logged in user is found the cookie is invalidated. The user will see a cached page on the next request.

Added the method `hasCookie` to the CookieService class to unify the cookie validation.

Related Issue
-------------

#339

More Details
------------

This resolves issue #339.


---

Some thoughts:

I wonder why frontend users should always bypass the staticfilecache? I think backend users should always bypass the staticfilecache to be able to see the latest preview. But frontend users normally have only a small user related section which is not cacheable due to USER_INT etc. The rest of the page should show the same content as always?!
Do I miss something? 
Should we have different cookies for frontend and backend user logins? This way the page owner can decide in the htaccess how to handle them? But it would add more complexity.

Just some thoughts about the cookie handling which came up during putting this PR together :-)
