### PR TITLE
[FEATURE] Add php file generator for use with nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.Build/
+/config
 /var
 /Tests/.phpunit.result.cache
 .DS_Store

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -24,6 +24,7 @@ use SFC\Staticfilecache\Generator\ConfigGenerator;
 use SFC\Staticfilecache\Generator\GzipGenerator;
 use SFC\Staticfilecache\Generator\HtaccessGenerator;
 use SFC\Staticfilecache\Generator\ManifestGenerator;
+use SFC\Staticfilecache\Generator\PhpGenerator;
 use SFC\Staticfilecache\Generator\PlainGenerator;
 use SFC\Staticfilecache\Hook\DatamapHook;
 use SFC\Staticfilecache\Hook\LogoffFrontendUser;
@@ -193,6 +194,10 @@ class Configuration extends StaticFileCacheObject
 
         if ($this->configuration['enableGeneratorManifest']) {
             $generator['manifest'] = ManifestGenerator::class;
+        }
+        if ($this->configuration['enableGeneratorPhp']) {
+            $generator['php'] = PhpGenerator::class;
+            unset($generator['htaccess']);
         }
         if ($this->configuration['enableGeneratorPlain']) {
             $generator['plain'] = PlainGenerator::class;

--- a/Classes/Generator/PhpGenerator.php
+++ b/Classes/Generator/PhpGenerator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SFC\Staticfilecache\Generator;
+
+use Psr\Http\Message\ResponseInterface;
+use SFC\Staticfilecache\Service\ConfigurationService;
+use SFC\Staticfilecache\Service\DateTimeService;
+use SFC\Staticfilecache\Service\RemoveService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * PlainGenerator.
+ */
+class PhpGenerator extends HtaccessGenerator
+{
+    /**
+     * Generate file.
+     */
+    public function generate(string $entryIdentifier, string $fileName, ResponseInterface $response, int $lifetime): void
+    {
+        $configuration = GeneralUtility::makeInstance(ConfigurationService::class);
+        $accessTimeout = (int) $configuration->get('htaccessTimeout');
+        $lifetime = $accessTimeout ?: $lifetime;
+
+        $headers = $this->getReponseHeaders($response);
+        if ($configuration->isBool('debugHeaders')) {
+            $headers['X-SFC-State'] = 'StaticFileCache - via htaccess';
+            $headers['X-SFC-Generator'] = 'PhpGenerator';
+        }
+        $headers = array_map(fn ($item) => str_replace('"', '\"', $item), $headers);
+
+        $currentTime = (new DateTimeService())->getCurrentTime();
+        $expires = $currentTime + $lifetime;
+        $requestUri = GeneralUtility::getIndpEnv('REQUEST_URI');
+
+        $methodCalls = [];
+        if ($configuration->isBool('sendCacheControlHeaderRedirectAfterCacheTimeout')) {
+            $methodCalls[] = "/* expires on " . date('Y-m-d H:i:s', $expires) . " */ if(time() > {$expires}) { unlink(__FILE__);header('Location: {$requestUri}'); };";
+        }
+
+        foreach ($headers as $header => $value) {
+            $methodCalls[] = "header('{$header}:{$value}');";
+        }
+
+        $php = '<?php /* generated on ' . date('r', $currentTime) . ' */ '. implode('', $methodCalls) . ' ?>';
+        GeneralUtility::writeFile($fileName.'.php', $php . (string) $response->getBody());
+    }
+
+    /**
+     * Remove file.
+     */
+    public function remove(string $entryIdentifier, string $fileName): void
+    {
+        $removeService = GeneralUtility::makeInstance(RemoveService::class);
+        $removeService->file($fileName.'.php');
+    }
+}

--- a/Documentation/Configuration/Htaccess.rst
+++ b/Documentation/Configuration/Htaccess.rst
@@ -49,7 +49,7 @@ variables (SFC_ROOT, SFC_GZIP) and read the comments carefully.
    # Full path for redirect
    RewriteRule .* - [E=SFC_FULLPATH:typo3temp/tx_staticfilecache/%{ENV:SFC_PROTOCOL}_%{ENV:SFC_HOST}_%{ENV:SFC_PORT}%{ENV:SFC_URI}/index]
 
-   # Extension (Order: br, gzip, default)
+   # Extension (Order: br, gzip, php, default)
    RewriteRule .* - [E=SFC_EXT:]
    RewriteCond %{HTTP:Accept-Encoding} br [NC]
    RewriteRule .* - [E=SFC_EXT:.br]
@@ -59,6 +59,10 @@ variables (SFC_ROOT, SFC_GZIP) and read the comments carefully.
    RewriteCond %{HTTP:Accept-Encoding} gzip [NC]
    RewriteRule .* - [E=SFC_EXT:.gz]
    RewriteCond %{ENV:SFC_EXT} ^\.gz$
+   RewriteCond %{ENV:SFC_ROOT}/%{ENV:SFC_FULLPATH}%{ENV:SFC_EXT} !-f
+   RewriteRule .* - [E=SFC_EXT:]
+   RewriteCond %{ENV:SFC_EXT} ^$
+   RewriteRule .* - [E=SFC_EXT:.php]
    RewriteCond %{ENV:SFC_ROOT}/%{ENV:SFC_FULLPATH}%{ENV:SFC_EXT} !-f
    RewriteRule .* - [E=SFC_EXT:]
 

--- a/Documentation/Configuration/Nginx.rst
+++ b/Documentation/Configuration/Nginx.rst
@@ -81,10 +81,27 @@ By the following configuration:
        deny all;
    }
 
+If you activate the php generator you need to use
+
+.. code-block:: nginx
+
+       try_files /typo3temp/tx_staticfilecache/${scheme}_${host}_${server_port}${uri}/
+             =405;
+
+instead of
+
+.. code-block:: nginx
+
+       try_files /typo3temp/tx_staticfilecache/${scheme}_${host}_${server_port}${uri}/index
+             /typo3temp/tx_staticfilecache/${scheme}_${host}_${server_port}${uri}
+             =405;
+
 *Extension configuration*
 
-Nginx does not interpret .htaccess files, therefore you may want to disable the
-htaccess genrator to prevent .htaccess generation.
+Nginx does not support .htaccess files and therefore cannot transfer HTML headers
+for the statically cached files. You should therefore activate the PHP generator,
+so that the static content is written to a PHP file via which the correct HTML
+headers are set.
 
 .. _location: http://nginx.org/en/docs/http/ngx_http_core_module.html#location
 .. _try_files: http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -40,6 +40,9 @@ overrideCacheDirectory =
 # cat=Generator; type=boolean; label=Enable Cache Manifest generator (BETA!!!): Create manifest files
 enableGeneratorManifest = 0
 
+# cat=Generator; type=boolean; label=Enable PHP generator: When checked, the php file including headers output will write to the cache. This will also disable the .htaccess file generation.
+enableGeneratorPhp = 0
+
 # cat=Generator; type=boolean; label=Enable Plain generator: When checked, the normal (default) file will write to the cache.
 enableGeneratorPlain = 0
 


### PR DESCRIPTION
Short description
-----------------

If you're using nginx to host your TYPO3 website with ext:staticfilecache you cannot get headers send to the visitors browsers, because nginx does not support setting headers outside of the vhost configuration. This feature will deliver all static content via a php file, which will set the configured headers for your cached resources.

Related Issue
-------------

#343
