### PR TITLE
[BUGFIX] Escape single quotes instead of double quotes

### DIFF
--- a/Classes/Generator/PhpGenerator.php
+++ b/Classes/Generator/PhpGenerator.php
@@ -29,7 +29,7 @@ class PhpGenerator extends HtaccessGenerator
         if ($configuration->isBool('debugHeaders')) {
             $headers['X-SFC-State'] = 'StaticFileCache - via PhpGenerator';
         }
-        $headers = array_map(fn ($item) => str_replace('"', '\"', $item), $headers);
+        $headers = array_map(fn ($item) => str_replace("'", "\'", $item), $headers);
         $requestUri = GeneralUtility::getIndpEnv('REQUEST_URI');
 
         $variables = [


### PR DESCRIPTION
Escape single quotes instead of double quotes

Fix a bug when using single quotes in headers like Content-Security-Policy headers. As the php template outputs headers via the `header('...')` method, the escaping of double quotes has been changed to escaping single quotes.