### PR TITLE
Fix #382 - Add headers that are stored in xxx.config.json correctly

### DIFF
--- a/Classes/Generator/ConfigGenerator.php
+++ b/Classes/Generator/ConfigGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SFC\Staticfilecache\Generator;
 
 use Psr\Http\Message\ResponseInterface;
+use SFC\Staticfilecache\Service\ConfigurationService;
 use SFC\Staticfilecache\Service\RemoveService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -20,7 +21,8 @@ class ConfigGenerator extends AbstractGenerator
     {
         $config = [
             'generated' => date('r'),
-            'headers' => $response->getHeaders(),
+            'headers' => GeneralUtility::makeInstance(ConfigurationService::class)
+                ->getValidHeaders($response->getHeaders(), 'validFallbackHeaders'),
         ];
         GeneralUtility::writeFile($fileName.'.config.json', json_encode($config, JSON_PRETTY_PRINT));
     }

--- a/Classes/Generator/HtaccessGenerator.php
+++ b/Classes/Generator/HtaccessGenerator.php
@@ -28,7 +28,7 @@ class HtaccessGenerator extends AbstractGenerator
         $accessTimeout = (int) $configuration->get('htaccessTimeout');
         $lifetime = $accessTimeout ?: $lifetime;
 
-        $headers = $this->getReponseHeaders($response);
+        $headers = $configuration->getValidHeaders($response->getHeaders(), 'validHtaccessHeaders');
         if ($configuration->isBool('debugHeaders')) {
             $headers['X-SFC-State'] = 'StaticFileCache - via htaccess';
         }
@@ -75,25 +75,6 @@ class HtaccessGenerator extends AbstractGenerator
         $htaccessFile = PathUtility::pathinfo($fileName, PATHINFO_DIRNAME) . '/.htaccess';
         $removeService = GeneralUtility::makeInstance(RemoveService::class);
         $removeService->file($htaccessFile);
-    }
-
-    /**
-     * Get reponse headers.
-     */
-    protected function getReponseHeaders(ResponseInterface $response): array
-    {
-        $configuration = GeneralUtility::makeInstance(ConfigurationService::class);
-        $validHeaders = GeneralUtility::trimExplode(',', $configuration->get('validHtaccessHeaders') . ',Content-Type', true);
-
-        $headers = $response->getHeaders();
-        $result = [];
-        foreach ($headers as $name => $values) {
-            if (\in_array($name, $validHeaders, true)) {
-                $result[$name] = implode(', ', $values);
-            }
-        }
-
-        return $result;
     }
 
     /**

--- a/Classes/Middleware/FallbackMiddleware.php
+++ b/Classes/Middleware/FallbackMiddleware.php
@@ -85,22 +85,22 @@ class FallbackMiddleware implements MiddlewareInterface
         return new HtmlResponse(GeneralUtility::getUrl($possibleStaticFile), 200, $headers);
     }
 
-    /**
-     * @return array
-     */
-    protected function getHeaders(ServerRequestInterface $request, string &$possibleStaticFile)
+    protected function getHeaders(ServerRequestInterface $request, string &$possibleStaticFile): array
     {
         $headers = [
             'Content-Type' => 'text/html; charset=utf-8',
         ];
         $config = $this->getCacheConfiguration($possibleStaticFile);
-        if (isset($config['headers']->{'Content-Type'})) {
-            $headers['Content-Type'] = implode(', ', $config['headers']->{'Content-Type'});
+
+        foreach ($config['headers'] as $header => $value) {
+            $headers[$header] = implode(', ', $value);
         }
+
         $debug = $this->configurationService->isBool('debugHeaders');
         if ($debug) {
             $headers['X-SFC-State'] = 'StaticFileCache - via Fallback Middleware';
         }
+
         foreach ($request->getHeader('accept-encoding') as $acceptEncoding) {
             if (str_contains($acceptEncoding, 'br')) {
                 if (is_file($possibleStaticFile.'.br') && is_readable($possibleStaticFile.'.br')) {
@@ -130,7 +130,7 @@ class FallbackMiddleware implements MiddlewareInterface
     {
         $configFile = $possibleStaticFile.'.config.json';
         if (is_file($configFile) || !is_readable($configFile)) {
-            return (array) json_decode((string) GeneralUtility::getUrl($configFile));
+            return (array) json_decode((string) GeneralUtility::getUrl($configFile), true);
         }
 
         return [];

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -87,6 +87,31 @@ class ConfigurationService extends AbstractService
     }
 
     /**
+     * Get the valid headers.
+     *
+     * @param array $headers
+     * @param string $configKey
+     * @return array
+     */
+    public function getValidHeaders(array $headers, string $configKey): array
+    {
+        $validHeaders = GeneralUtility::trimExplode(
+            ',',
+            $this->get($configKey) . ',Content-Type',
+            true
+        );
+
+        $result = [];
+        foreach ($headers as $name => $values) {
+            if (in_array($name, $validHeaders)) {
+                $result[$name] = implode(', ', $values);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Get backend display mode.
      */
     public function getBackendDisplayMode(): string

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,6 +13,9 @@ debugHeaders = 0
 # cat=basic; type=string; label=Valid .htaccess headers: List of headers that are transferred to the .htaccess configuration. E.g. if you use config.additionalHeaders.xxx you can add this headers here. Please change this configuration only, if you know what you do. "Content-Type" is recommended. Note: Content-Type will be added automatically.
 validHtaccessHeaders = Content-Type,Content-Language,Link,X-SFC-Tags
 
+# cat=basic; type=string; label=Valid fallback middleware headers: List of headers that are transferred to the xxx.config.json file. E.g. if you use config.additionalHeaders.xxx and you have useFallbackMiddleware set to true, you can add this headers here. Please change this configuration only, if you know what you do. "Content-Type" is recommended. Note: Content-Type will be added automatically.
+validFallbackHeaders = Content-Type,Content-Language,Link,X-SFC-Tags
+
 # cat=basic; type=boolean; label=Disable StaticFileCache in development: When checked, the StaticFileCache won't be generated if in development application context.
 disableInDevelopment = 0
 


### PR DESCRIPTION
Short description
-----------------
This PR add the headers that are stored in xxx.config.json to the response correctly.
In fact, when using the FallbackMiddleware, the headers were not added correctly.

Related Issue
-------------
#382 

