### PR TITLE
Restore typo3v12/symfony compability (vaguely tested in one instance)

### DIFF
--- a/Classes/Command/AbstractCommand.php
+++ b/Classes/Command/AbstractCommand.php
@@ -18,7 +18,7 @@ abstract class AbstractCommand extends Command
      *
      * @return Command
      */
-    public function setDescription($description)
+    public function setDescription($description): static
     {
         return parent::setDescription('StaticFileCache task: '.$description);
     }

--- a/Classes/Middleware/FallbackMiddleware.php
+++ b/Classes/Middleware/FallbackMiddleware.php
@@ -93,7 +93,7 @@ class FallbackMiddleware implements MiddlewareInterface
         $config = $this->getCacheConfiguration($possibleStaticFile);
 
         foreach ($config['headers'] as $header => $value) {
-            $headers[$header] = implode(', ', $value);
+            $headers[$header] = $value;
         }
 
         $debug = $this->configurationService->isBool('debugHeaders');


### PR DESCRIPTION
Short description
-----------------

This PR makes the extension work under typo3/cms-core:v12.2.0 as well as symfony/console:v6.2.5. This has been successfully tested in one sample project. This fixes two error messages:
- `implode(): Argument #2 ($array) must be of type ?array, string given in Classes/Middleware/FallbackMiddleware.php line 96`
- `Fatal error: Declaration of SFC\Staticfilecache\Command\AbstractCommand::setDescription($description) must be compatible with Symfony\Component\Console\Command\Command::setDescription(string $description): static in Classes/Command/AbstractCommand.php on line 21`

Related Issue
-------------

...

More Details
------------

- I only fixed one ocurrence of a broken implode use, there may be more errors to fix and this PR just makes it so the project works in general and caches are created.
