### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
 		"ext-zlib": "*",
 		"typo3/cms-core": "^11.5||^12.4",
 		"typo3/cms-backend": "^11.5||^12.4",
-		"typo3/cms-extensionmanager": "^11.5||^12.4"
+		"typo3/cms-extensionmanager": "^11.5||^12.4",
+		"friendsoftypo3/fontawesome-provider": "^1.0"
 	},
 	"replace": {
 		"typo3-ter/staticfilecache": "self.version"


### PR DESCRIPTION


Short description
-----------------

FontAwesome was removed in TYPO3 v12 and was extracted into a separate extension. https://docs.typo3.org/p/friendsoftypo3/fontawesome-provider/main/en-us/


