### PR TITLE
🛠️  [TASK] Handle Content-Security-Policy headers of TYPO3 v12

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -29,7 +29,6 @@ use SFC\Staticfilecache\Generator\ManifestGenerator;
 use SFC\Staticfilecache\Generator\PhpGenerator;
 use SFC\Staticfilecache\Generator\PlainGenerator;
 use SFC\Staticfilecache\Hook\DatamapHook;
-use SFC\Staticfilecache\Hook\LogoffFrontendUser;
 use SFC\Staticfilecache\Service\ConfigurationService;
 use SFC\Staticfilecache\Service\HttpPush\FontHttpPush;
 use SFC\Staticfilecache\Service\HttpPush\ImageHttpPush;
@@ -39,6 +38,7 @@ use SFC\Staticfilecache\Service\HttpPush\SvgHttpPush;
 use SFC\Staticfilecache\Service\ObjectFactoryService;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
@@ -50,6 +50,7 @@ class Configuration extends StaticFileCacheObject
     public const EXTENSION_KEY = 'staticfilecache';
 
     protected ConfigurationService $configurationService;
+    protected Typo3Version $typo3version;
 
     /**
      * Configuration constructor.
@@ -60,6 +61,7 @@ class Configuration extends StaticFileCacheObject
     public function __construct()
     {
         $this->configurationService = GeneralUtility::makeInstance(ConfigurationService::class);
+        $this->typo3version = GeneralUtility::makeInstance(Typo3Version::class);
     }
 
     /**
@@ -88,6 +90,10 @@ class Configuration extends StaticFileCacheObject
      */
     protected function registerBackendModule(): self
     {
+        // see `Configuration/Backend/Modules.php` (since TYPO3 v12)
+        if ($this->typo3version->getMajorVersion() >= 12) {
+            return $this;
+        }
         ExtensionUtility::registerModule(
             'Staticfilecache',
             'web',

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -74,6 +74,7 @@ class Configuration extends StaticFileCacheObject
             ->registerCachingFramework()
             ->registerGenerators()
             ->registerHttpPushServices()
+            ->adjustSystemSettings()
         ;
     }
 
@@ -221,6 +222,15 @@ class Configuration extends StaticFileCacheObject
             'svg' => SvgHttpPush::class,
         ]);
 
+        return $this;
+    }
+
+    protected function adjustSystemSettings(): self
+    {
+        if ($this->typo3version->getMajorVersion() >= 12) {
+            // aim for cacheable frontend responses when using TYPO3's `Content-Security-Policy` behavior
+            $GLOBALS['TYPO3_CONF_VARS']['FE']['contentSecurityPolicy']['preferCacheableResponse'] = true;
+        }
         return $this;
     }
 }

--- a/Classes/ViewHelpers/Format/StripEmptyVerticalSpacesViewHelper.php
+++ b/Classes/ViewHelpers/Format/StripEmptyVerticalSpacesViewHelper.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace SFC\Staticfilecache\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+class StripEmptyVerticalSpacesViewHelper extends AbstractViewHelper
+{
+    public function render(): string
+    {
+        $content = $this->renderChildren();
+        return preg_replace('#^\h*\v#ms', '', $content);
+    }
+}

--- a/Resources/Private/Layouts/Backend.html
+++ b/Resources/Private/Layouts/Backend.html
@@ -1,4 +1,0 @@
-<div class="staticfilecache">
-	<f:flashMessages/>
-	<f:render section="Content"/>
-</div>

--- a/Resources/Private/Partials/Backend/ListEntry.html
+++ b/Resources/Private/Partials/Backend/ListEntry.html
@@ -1,8 +1,8 @@
 <tr>
 	<td>
-		<f:format.raw>{row.title}</f:format.raw> <i>[{row.uid}]</i>
+		{row.title -> f:sanitize.html()} <i>[{row.uid}]</i>
 	</td>
-	<td><a href="{row.identifier}">{row.identifier}</a>
+	<td><a href="{row.identifier}" target="_blank">{row.identifier}</a>
 		<f:if condition="{row.cached}">
 			<f:then>
 				<core:icon identifier="status-status-permission-granted"/>

--- a/Resources/Private/Templates/Backend/Boost.html
+++ b/Resources/Private/Templates/Backend/Boost.html
@@ -1,4 +1,4 @@
-<f:layout name="Backend"/>
+<f:layout name="Module"/>
 
 <f:section name="Content">
 

--- a/Resources/Private/Templates/Backend/List.html
+++ b/Resources/Private/Templates/Backend/List.html
@@ -1,4 +1,4 @@
-<f:layout name="Backend"/>
+<f:layout name="Module"/>
 
 <f:section name="Content">
 

--- a/Resources/Private/Templates/Backend/Support.html
+++ b/Resources/Private/Templates/Backend/Support.html
@@ -1,4 +1,4 @@
-<f:layout name="Backend"/>
+<f:layout name="Module"/>
 
 <f:section name="Content">
 

--- a/Resources/Private/Templates/Htaccess.html
+++ b/Resources/Private/Templates/Htaccess.html
@@ -1,11 +1,14 @@
 {escaping off}
+{namespace sfc=SFC\Staticfilecache\ViewHelpers}
 ForceType {contentType}
+<sfc:format.stripEmptyVerticalSpaces>
 <f:if condition="{sendCacheControlHeader}">
 <IfModule mod_expires.c>
 	ExpiresActive on
 	ExpiresByType {contentType} {mode}{lifetime}
 </IfModule>
 </f:if>
+
 <f:if condition="{sendCacheControlHeaderRedirectAfterCacheTimeout}">
 <IfModule mod_rewrite.c>
 	RewriteEngine On
@@ -22,9 +25,18 @@ ForceType {contentType}
 </f:if>
 
 <f:if condition="{headers}">
-	<IfModule mod_headers.c>
-		<f:for each="{headers}" key="name" as="value">
-				Header set {name} "{value}"
-		</f:for>
-	</IfModule>
+<IfModule mod_headers.c>
+<f:for each="{headers}" key="name" as="value">
+	Header set {name} "{value}"
+	<f:if condition="{name} == 'Content-Security-Policy'">
+	<f:comment><!--
+		see https://httpd.apache.org/docs/2.4/mod/mod_headers.html
+		`%t` results in `t=[unixtime in microseconds]`, thus `&t=` needs to be stripped
+	--></f:comment>
+	Header edit Content-Security-Policy (@http-reporting\?csp=report&requestTime=)\d+ $1@t&%t
+	Header edit Content-Security-Policy (@http-reporting\?csp=report&requestTime=)@t&t=(\d+) $1$2
+	</f:if>
+</f:for>
+</IfModule>
 </f:if>
+</sfc:format.stripEmptyVerticalSpaces>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -11,10 +11,10 @@ backendDisplayMode = both
 debugHeaders = 0
 
 # cat=basic; type=string; label=Valid .htaccess headers: List of headers that are transferred to the .htaccess configuration. E.g. if you use config.additionalHeaders.xxx you can add this headers here. Please change this configuration only, if you know what you do. "Content-Type" is recommended. Note: Content-Type will be added automatically.
-validHtaccessHeaders = Content-Type,Content-Language,Link,X-SFC-Tags
+validHtaccessHeaders = Content-Type,Content-Language,Content-Security-Policy,Link,X-SFC-Tags
 
 # cat=basic; type=string; label=Valid fallback middleware headers: List of headers that are transferred to the xxx.config.json file. E.g. if you use config.additionalHeaders.xxx and you have useFallbackMiddleware set to true, you can add this headers here. Please change this configuration only, if you know what you do. "Content-Type" is recommended. Note: Content-Type will be added automatically.
-validFallbackHeaders = Content-Type,Content-Language,Link,X-SFC-Tags
+validFallbackHeaders = Content-Type,Content-Language,Content-Security-Policy,Link,X-SFC-Tags
 
 # cat=basic; type=boolean; label=Disable StaticFileCache in development: When checked, the StaticFileCache won't be generated if in development application context.
 disableInDevelopment = 0


### PR DESCRIPTION
# Short description

Fully cacheable responses must avoid using Content-Security-Policy nonce values in HTTP headers and the generated HTML markup. This change adjusts the TYPO3 `PolicyBehavior` to aim for cacheable responses and therefore to use static hash values instead of dynamic nonce values.

# Related Issues

* #389
* https://review.typo3.org/c/Packages/TYPO3.CMS/+/80554 (required TYPO3 v12 core change)

# More Details

* the configuration properties `validHtaccessHeaders` and `validFallbackHeaders` were extended by `Content-Security-Policy` (this has to be adjusted manually in the file`system/settings.php` of the corresponding TYPO3 instance)
* the Apache `.htaccess` generator was adjusted to update the reporting URI that might potentially being used the `Content-Security-Policy` HTTP header, e.g. the corresponding section in the generated `.htaccess` file would look like this

```
<IfModule mod_headers.c>
	Header set Content-Type "text/html; charset=utf-8"
	Header set Content-Language "en-US"
	Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'report-sample'; style-src-attr 'unsafe-inline' 'report-sample'; img-src 'self' data: *.ytimg.com *.vimeocdn.com; base-uri 'self'; frame-src 'self' *.youtube-nocookie.com *.youtube.com *.vimeo.com; style-src-elem 'self' 'sha256-2jHA7HeLLRBxTLZh3hq5WwCT4sUgYEBWVrYarn//8dA=' 'sha256-6kBl4fibHaZ3yHgzIfBZGSMc9aQsl6Qz024e1PHYzwg=' 'sha256-hsci338HivFL5/1oLdltJy0V2cnmBXK6hq9S1RmxBOI=' 'report-sample'; script-src-elem 'self' 'sha256-jFj1HeJo8v0RAIOenIw0qtV3yom5jiHWB/v7fHZSRC4=' 'sha256-MJesaYFpH4OSpy12iDLxyeIfcVYNXN8OrlRaWAY/HG8=' 'report-sample'; report-uri https://ip13.anyhost.it/@http-reporting?csp=report&requestTime=1699187708212996"
	Header edit Content-Security-Policy (@http-reporting\?csp=report&requestTime=)\d+ $1@t&%t
	Header edit Content-Security-Policy (@http-reporting\?csp=report&requestTime=)@t&t=(\d+) $1$2
	Header set X-SFC-Tags "pageId_1"
</IfModule>
```