### PR TITLE
Redirect error when using felogin

### DIFF
--- a/Classes/Middleware/FrontendUserMiddleware.php
+++ b/Classes/Middleware/FrontendUserMiddleware.php
@@ -49,6 +49,10 @@ class FrontendUserMiddleware implements MiddlewareInterface
 
     protected function weShouldHaveCookie(FrontendUserAuthentication $feUser, ServerRequestInterface $request): bool
     {
+        if ($GLOBALS['TYPO3_REQUEST'] === null) {
+            $GLOBALS['TYPO3_REQUEST'] = $request;
+        }
+
         $setCookieHeader = $feUser->appendCookieToResponse(new HtmlResponse(''))->getHeaderLine('Set-Cookie');
 
         if (strpos($setCookieHeader, 'Max-Age=0')) {

--- a/Classes/Middleware/FrontendUserMiddleware.php
+++ b/Classes/Middleware/FrontendUserMiddleware.php
@@ -49,11 +49,7 @@ class FrontendUserMiddleware implements MiddlewareInterface
 
     protected function weShouldHaveCookie(FrontendUserAuthentication $feUser, ServerRequestInterface $request): bool
     {
-        if ($GLOBALS['TYPO3_REQUEST'] === null) {
-            $GLOBALS['TYPO3_REQUEST'] = $request;
-        }
-
-        $setCookieHeader = $feUser->appendCookieToResponse(new HtmlResponse(''))->getHeaderLine('Set-Cookie');
+        $setCookieHeader = $feUser->appendCookieToResponse(new HtmlResponse(''), $request->getAttribute('normalizedParams'))->getHeaderLine('Set-Cookie');
 
         if (strpos($setCookieHeader, 'Max-Age=0')) {
             // the new cookie is to delete the old cookie:


### PR DESCRIPTION
Short description
-----------------

Hello, I am getting an error with sys_redirct URLs in `staticfilecache/Classes/Middleware/FrontendUserMiddleware.php`
`$feUser->appendCookieToResponse` tries to access `$GLOBALS['TYPO3_REQUEST']`, which is not set in this situation.

TYPO3 Exception Screenshot:

> https://github.com/lochmueller/staticfilecache/assets/84477901/ea573bde-e84e-4d5f-babd-9e2af569479a

Related Issue
-------------

none

More Details
------------

This PR sets the `$GLOBALS['TYPO3_REQUEST']` variable to the current `$request` available in the middleware.
Both are typed as `TYPO3\CMS\Core\Http\ServerRequest`.

Best regards.