### PR TITLE
[TASK] Use context API instead of TSFE

### DIFF
--- a/Classes/Cache/Rule/NoWorkspacePreview.php
+++ b/Classes/Cache/Rule/NoWorkspacePreview.php
@@ -5,20 +5,25 @@ declare(strict_types=1);
 namespace SFC\Staticfilecache\Cache\Rule;
 
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Core\Context\Context;
 
 /**
  * No workspace preview.
  */
 class NoWorkspacePreview extends AbstractRule
 {
+    public function __construct(
+        private readonly Context $context,
+    )
+    {
+    }
+
     /**
      * Check if it is no workspace preview.
      */
     public function checkRule(ServerRequestInterface $request, array &$explanation, bool &$skipProcessing): void
     {
-        $tsfe = $GLOBALS['TSFE'] ?? null;
-        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->getContext()->getPropertyFromAspect('workspace', 'isOffline', false)) {
+        if ($this->context->getPropertyFromAspect('workspace', 'isOffline', false)) {
             $explanation[__CLASS__] = 'The page is in workspace preview mode';
         }
     }


### PR DESCRIPTION
Short description
-----------------

In TYPO3 v13 `TypoScriptFrontendController->getContext()` has been marked as @internal`.

