### PR TITLE
[TASK] Use Connection instead of PDO

### DIFF
--- a/Classes/Domain/Repository/CacheRepository.php
+++ b/Classes/Domain/Repository/CacheRepository.php
@@ -6,6 +6,7 @@ namespace SFC\Staticfilecache\Domain\Repository;
 
 use SFC\Staticfilecache\Service\ConfigurationService;
 use SFC\Staticfilecache\Service\DateTimeService;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -23,7 +24,7 @@ class CacheRepository extends AbstractRepository
             ->from($this->getTableName())
             ->where($queryBuilder->expr()->lt(
                 'expires',
-                $queryBuilder->createNamedParameter((new DateTimeService())->getCurrentTime(), \PDO::PARAM_INT)
+                $queryBuilder->createNamedParameter((new DateTimeService())->getCurrentTime(), Connection::PARAM_INT)
             ))
             ->groupBy('identifier')
             ->executeQuery()


### PR DESCRIPTION
Short description
-----------------
In Doctrine DBAL v4, as described in the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#database-query-builder-create-named-parameter), support for using the `\PDO::PARAM_*` constants has been dropped in favor of the enum types. This should be migrated to `Connection::PARAM_*` in order to be compatible with TYPO3 v13 later on. `Connection::PARAM_*` can already be used now as it is compatible with TYPO3 11 and 12.