### PR TITLE
[BUGFIX] Added missing middleware implementing frontend.cache.instruction for TYPO3 v13

### DIFF
--- a/Classes/Cache/Rule/NoNoCache.php
+++ b/Classes/Cache/Rule/NoNoCache.php
@@ -19,7 +19,7 @@ class NoNoCache extends AbstractRule
     {
         $tsfe = $GLOBALS['TSFE'] ?? null;
         /* @phpstan-ignore-next-line */
-        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->config['config']['no_cache']) {
+        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->no_cache) {
             $explanation[__CLASS__] = 'config.no_cache is true';
         }
     }

--- a/Classes/Cache/Rule/NoNoCache.php
+++ b/Classes/Cache/Rule/NoNoCache.php
@@ -19,7 +19,7 @@ class NoNoCache extends AbstractRule
     {
         $tsfe = $GLOBALS['TSFE'] ?? null;
         /* @phpstan-ignore-next-line */
-        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->no_cache) {
+        if ($tsfe instanceof TypoScriptFrontendController && $tsfe->config['config']['no_cache']) {
             $explanation[__CLASS__] = 'config.no_cache is true';
         }
     }

--- a/Classes/Middleware/FrontendCacheMiddleware.php
+++ b/Classes/Middleware/FrontendCacheMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SFC\Staticfilecache\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Frontend\Cache\CacheInstruction;
+
+class FrontendCacheMiddleware implements MiddlewareInterface
+{
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        // Get the attribute, if not available, use a new CacheInstruction object
+        $cacheInstruction = $request->getAttribute(
+            'frontend.cache.instruction',
+            new CacheInstruction(),
+        );
+
+        // Disable the cache and give a reason
+        $cacheInstruction->disableCache('EXT:staticfilecache: Cache is disabled');
+
+        // Write back the cache instruction to the attribute
+        $request = $request->withAttribute('frontend.cache.instruction', $cacheInstruction);
+
+        return $handler->handle($request);
+    }
+}

--- a/Classes/Middleware/FrontendCacheMiddleware.php
+++ b/Classes/Middleware/FrontendCacheMiddleware.php
@@ -13,21 +13,23 @@ use TYPO3\CMS\Frontend\Cache\CacheInstruction;
 class FrontendCacheMiddleware implements MiddlewareInterface
 {
     public function process(
-        ServerRequestInterface $request,
+        ServerRequestInterface  $request,
         RequestHandlerInterface $handler,
-    ): ResponseInterface {
-        // Get the attribute, if not available, use a new CacheInstruction object
-        $cacheInstruction = $request->getAttribute(
-            'frontend.cache.instruction',
-            new CacheInstruction(),
-        );
+    ): ResponseInterface
+    {
+        if (class_exists(CacheInstruction::class)) {
+            // Get the attribute, if not available, use a new CacheInstruction object
+            $cacheInstruction = $request->getAttribute(
+                'frontend.cache.instruction',
+                new CacheInstruction(),
+            );
 
-        // Disable the cache and give a reason
-        $cacheInstruction->disableCache('EXT:staticfilecache: Cache is disabled');
+            // Disable the cache and give a reason
+            $cacheInstruction->disableCache('EXT:staticfilecache: Cache is disabled');
 
-        // Write back the cache instruction to the attribute
-        $request = $request->withAttribute('frontend.cache.instruction', $cacheInstruction);
-
+            // Write back the cache instruction to the attribute
+            $request = $request->withAttribute('frontend.cache.instruction', $cacheInstruction);
+        }
         return $handler->handle($request);
     }
 }

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use SFC\Staticfilecache\Middleware\CookieCheckMiddleware;
 use SFC\Staticfilecache\Middleware\FallbackMiddleware;
 use SFC\Staticfilecache\Middleware\FrontendUserMiddleware;
+use SFC\Staticfilecache\Middleware\FrontendCacheMiddleware;
 use SFC\Staticfilecache\Middleware\GenerateMiddleware;
 use SFC\Staticfilecache\Middleware\PrepareMiddleware;
 

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -41,6 +41,15 @@ return [
                 'staticfilecache/generate',
             ],
         ],
+        'staticfilecache/frontend-cache' => [
+            'target' => FrontendCacheMiddleware::class,
+            'after' => [
+                'typo3/cms-frontend/authentication',
+            ],
+            'before' => [
+                'staticfilecache/generate',
+            ],
+        ],
         'staticfilecache/cookie-check' => [
             'target' => CookieCheckMiddleware::class,
             'before' => [


### PR DESCRIPTION
### Description

In TYPO3 v13, the [frontend.cache.instruction](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheInstruction.html#frontend-cache-instruction) got introduced as a replacement for the now internal TypoScriptFrontendController->no_cache property.
During development / implementation for an TYPO3 v13.2.1 installation i saw, that the middleware hasn't been implemented yet, which results in an error in the backend after installation.

### Related Issues

Possibly #410 
