### PR TITLE
FIX: The BackendController::supportAction show the Boost-Template instead of the Support-Template

### DIFF
--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -85,7 +85,7 @@ class BackendController extends ActionController
 
         return $this->createModuleTemplate()
             ->assignMultiple($viewVariables)
-            ->renderResponse('Backend/Boost');
+            ->renderResponse('Backend/Support');
     }
 
     /**


### PR DESCRIPTION
Short description
-----------------
The Support-Tab in the Backend-Module shows the Boost-Template (too) and not the support-template. Changed this to show the Support-Template.

More Details
------------
Just noticed while clicking through the Backend-Module that the Support-Tab show the same content as the Boost-Tab (but with error message). Fixed that here :)