### PR TITLE
Disable cache for EXT:crawler indexing requests

### DIFF
--- a/Classes/Cache/Listener/T3CrawlerIndexingProcessListener.php
+++ b/Classes/Cache/Listener/T3CrawlerIndexingProcessListener.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SFC\Staticfilecache\Cache\Listener;
+
+use SFC\Staticfilecache\Event\CacheRuleFallbackEvent;
+
+/**
+ * T3Crawler Indexing process.
+ */
+class T3CrawlerIndexingProcessListener
+{
+    public function __invoke(CacheRuleFallbackEvent $event): void
+    {
+        if ($event->getRequest()->hasHeader('X-T3Crawler')) {
+            $event->addExplanation(__CLASS__, 'T3Crawler Indexing request');
+            $event->setSkipProcessing(true);
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -52,6 +52,12 @@ services:
         identifier: 'SolrIndexingProcessListenerFallback'
         event: SFC\Staticfilecache\Event\CacheRuleFallbackEvent
 
+  SFC\Staticfilecache\Cache\Listener\T3CrawlerIndexingProcessListener:
+    tags:
+      - name: event.listener
+        identifier: 'T3CrawlerIndexingProcessListenerFallback'
+        event: SFC\Staticfilecache\Event\CacheRuleFallbackEvent
+
   SFC\Staticfilecache\Cache\Listener\ValidRequestMethodListener:
     tags:
       - name: event.listener

--- a/Documentation/Configuration/Htaccess.rst
+++ b/Documentation/Configuration/Htaccess.rst
@@ -31,6 +31,10 @@ variables (SFC_ROOT, SFC_GZIP) and read the comments carefully.
    RewriteCond %{HTTP:X-Tx-Solr-Iq} .+
    RewriteRule .* - [E=SFC_HOST:invalid-host]
 
+	# Disable cache for EXT:crawler indexing requests
+	RewriteCond %{HTTP:X-T3Crawler} .+
+	RewriteRule .* - [E=SFC_HOST:invalid-host]
+
    # Important Note for scheme and port. TYPO3 handle Reverse proxies by respect
    # X-Forwarded-For headers. The Apache do not know this configuration. If there
    # is a reverse proxy that e.g. terminate SSL and all requests are "http", please

--- a/Documentation/Configuration/Nginx.rst
+++ b/Documentation/Configuration/Nginx.rst
@@ -70,6 +70,11 @@ By the following configuration:
            return 405;
        }
 
+       # Disable cache for EXT:crawler indexing requests
+       if ($http_x_t3crawler) {
+           return 405;
+       }
+
        charset utf-8;
        default_type text/html;
        try_files /typo3temp/assets/tx_staticfilecache/${scheme}_${host}_${server_port}${uri}/index


### PR DESCRIPTION
Fix #428 - Add EXT:crawler indexing check for htaccess, nginx and fallback middleware