### PR TITLE
[FEATURE] Improve max header size handling

### DIFF
--- a/Classes/Generator/HtaccessGenerator.php
+++ b/Classes/Generator/HtaccessGenerator.php
@@ -49,9 +49,16 @@ class HtaccessGenerator extends AbstractGenerator
 
     protected function cleanupHeaderValues(array $headers): array
     {
+        $configurationService = $this->getConfigurationService();
+        $maxHeaderSize = (int)($configurationService->get('maxHeaderSize') ?? 8192);
+        $headerSizeBuffer = (int)($configurationService->get('headerSizeBuffer') ?? 0);
+
+        if($headerSizeBuffer > 0){
+            $maxHeaderSize = (int)($maxHeaderSize / $headerSizeBuffer);
+        }
         // respect max length
         foreach ($headers as $key => $value) {
-            $headers[$key] = substr((string) $value, 0, 1024 * 8); // 8K Max header for Apache
+            $headers[$key] = substr((string) $value, 0, $maxHeaderSize); // 8K Max header for Apache
         }
 
         // illegal chars

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,6 +13,12 @@ overrideClientUserAgent =
 # cat=basic; type=boolean; label=Debug headers: Send debug headers to get a information which component deliver the file (X-SFC-State).
 debugHeaders = 0
 
+# cat=basic; type=int+; label=The maximum allowed header size from your apache / nginx / webserver configuration
+maxHeaderSize = 8192
+
+# cat=basic; type=string; label=Reduce the maxHeaderSize with this buffer to keep space if you would reach the maxHeaderSize
+headerSizeBuffer = 1.5
+
 # cat=basic; type=string; label=Valid .htaccess headers: List of headers that are transferred to the .htaccess configuration. E.g. if you use config.additionalHeaders.xxx you can add this headers here. Please change this configuration only, if you know what you do. "Content-Type" is recommended. Note: Content-Type will be added automatically.
 validHtaccessHeaders = Content-Type,Content-Language,Content-Security-Policy,Link,X-SFC-Tags
 


### PR DESCRIPTION
This patch helps to handle the max header size problem. You can define your own header size if your webserver respect another size. You can also define a custom header size buffer for you to prevent that you always use the max size.


