### PR TITLE
Performance improvements for boost mode

### DIFF
--- a/Classes/Command/BoostQueueCommand.php
+++ b/Classes/Command/BoostQueueCommand.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Command;
 
+use Doctrine\DBAL\Exception;
 use SFC\Staticfilecache\Domain\Repository\QueueRepository;
 use SFC\Staticfilecache\Service\QueueService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
 
 class BoostQueueCommand extends AbstractCommand
 {
+    protected const DEFAULT_BATCH_SIZE = 50;
+    protected const DEFAULT_CLEANUP_BATCH_SIZE = 1000;
+    protected const DEFAULT_CONCURRENCY = 10;
+
     public function __construct(protected QueueRepository $queueRepository, protected QueueService $queueService)
     {
         parent::__construct();
@@ -24,31 +30,92 @@ class BoostQueueCommand extends AbstractCommand
         $this->addOption('limit-items', null, InputOption::VALUE_REQUIRED, 'Limit the items that are crawled. 0 => all', 500)
             ->addOption('stop-processing-after', null, InputOption::VALUE_REQUIRED, 'Stop crawling new items after N seconds since scheduler task started. 0 => infinite', 240)
             ->addOption('avoid-cleanup', null, InputOption::VALUE_NONE, 'Avoid the cleanup of the queue items')
+            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, 'Number of items to process in a single batch', self::DEFAULT_BATCH_SIZE)
+            ->addOption('concurrency', null, InputOption::VALUE_REQUIRED, 'Number of concurrent requests to run within a batch', self::DEFAULT_CONCURRENCY)
         ;
     }
 
+    /**
+     * @throws NoSuchCacheException
+     * @throws Exception
+     * @throws \Throwable
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
         $startTime = time();
         $stopProcessingAfter = (int) $input->getOption('stop-processing-after');
-        $limit = (int) $input->getOption('limit-items');
-        $limit = $limit > 0 ? $limit : 5000;
+        $totalLimit = (int) $input->getOption('limit-items');
+        $totalLimit = $totalLimit > 0 ? $totalLimit : 5000;
 
-        $count = 0;
-        foreach ($this->queueRepository->findOpen($limit) as $runEntry) {
+        $batchSize = (int) $input->getOption('batch-size');
+        $batchSize = $batchSize > 0 ? $batchSize : self::DEFAULT_BATCH_SIZE;
+        $batchSize = min($batchSize, $totalLimit);
+
+        $concurrency = (int) $input->getOption('concurrency');
+        $concurrency = $concurrency > 0 ? $concurrency : self::DEFAULT_CONCURRENCY;
+
+        $queueCount = $this->queueRepository->countOpen();
+        $io->writeln(sprintf(
+            'Found %d items in queue. Will process up to %d items with batch size %d.',
+            $queueCount,
+            $totalLimit,
+            $batchSize
+        ));
+
+        $processedCount = 0;
+        $successCount = 0;
+        $failedCount = 0;
+        $offset = 0;
+
+        while ($processedCount < $totalLimit) {
             if ($stopProcessingAfter > 0 && time() >= $startTime + $stopProcessingAfter) {
-                $io->note('Skip after "stopProcessingAfter" time.');
-
+                $io->note(sprintf('Stopping after %d seconds as requested.', $stopProcessingAfter));
                 break;
             }
 
-            $this->queueService->runSingleRequest($runEntry);
-            $count++;
+            $entriesBatch = $this->queueRepository->findOpenBatch($batchSize, $offset);
+
+            if (empty($entriesBatch)) {
+                $io->note('No more items in queue.');
+                break;
+            }
+
+            $statusResults = $this->queueService->runBatchRequests($entriesBatch, $concurrency);
+
+            $batchSuccess = count(array_filter($statusResults, fn($status) => $status === 200));
+            $successCount += $batchSuccess;
+            $failedCount += (count($entriesBatch) - $batchSuccess);
+
+            $processedCount += count($entriesBatch);
+
+            $io->writeln(sprintf(
+                'Processed batch of %d items (%d total, %d successful, %d failed).',
+                count($entriesBatch),
+                $processedCount,
+                $successCount,
+                $failedCount
+            ));
+
+            if (count($entriesBatch) < $batchSize) {
+                break;
+            }
+
+            $offset += $batchSize;
         }
 
-        $io->success($count . ' items are done (perhaps not all are processed).');
+        $duration = time() - $startTime;
+        $rate = $duration > 0 ? round($processedCount / $duration, 2) : $processedCount;
+
+        $io->success(sprintf(
+            '%d items processed in %d seconds (%.2f items/sec). Success: %d, Failed: %d',
+            $processedCount,
+            $duration,
+            $rate,
+            $successCount,
+            $failedCount
+        ));
 
         if (!(bool) $input->getOption('avoid-cleanup')) {
             $this->cleanupQueue($io);
@@ -57,14 +124,33 @@ class BoostQueueCommand extends AbstractCommand
         return self::SUCCESS;
     }
 
-
+    /**
+     * @throws Exception
+     */
     protected function cleanupQueue(SymfonyStyle $io): void
     {
-        $count = 0;
-        foreach ($this->queueRepository->findOldUids() as $row) {
-            $this->queueRepository->delete(['uid' => $row['uid']]);
-            $count++;
+        $startTime = microtime(true);
+        $totalDeleted = 0;
+        $batchSize = self::DEFAULT_CLEANUP_BATCH_SIZE;
+
+        $io->writeln('Starting batch cleanup of old queue entries...');
+
+        while (true) {
+            $batch = $this->queueRepository->findOldBatch($batchSize);
+            if (empty($batch)) {
+                break;
+            }
+
+            $uids = array_column($batch, 'uid');
+            $count = $this->queueRepository->bulkDelete($uids);
+            $totalDeleted += $count;
+
+            if (count($batch) < $batchSize) {
+                break;
+            }
         }
-        $io->success($count . ' items are removed.');
+
+        $duration = round(microtime(true) - $startTime, 2);
+        $io->success(sprintf('%d items removed in %s seconds.', $totalDeleted, $duration));
     }
 }

--- a/Classes/Command/FlushCacheCommand.php
+++ b/Classes/Command/FlushCacheCommand.php
@@ -8,6 +8,8 @@ use SFC\Staticfilecache\Service\CacheService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException;
+use TYPO3\CMS\Core\Cache\Exception\NoSuchCacheGroupException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class FlushCacheCommand extends AbstractCommand
@@ -18,6 +20,10 @@ class FlushCacheCommand extends AbstractCommand
         $this->addOption('force-boost-mode-flush', null, InputOption::VALUE_NONE, 'Force a boost mode flush');
     }
 
+    /**
+     * @throws NoSuchCacheException
+     * @throws NoSuchCacheGroupException
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $cacheService = GeneralUtility::makeInstance(CacheService::class);

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Domain\Repository;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Exception;
+
 class QueueRepository extends AbstractRepository
 {
     /**
@@ -22,6 +25,23 @@ class QueueRepository extends AbstractRepository
             ->executeQuery()
             ->iterateAssociative()
         ;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function findOpenBatch(int $limit = 100, int $offset = 0): array
+    {
+        $queryBuilder = $this->createQuery();
+
+        return $queryBuilder->select('*')
+            ->from($this->getTableName())
+            ->where($queryBuilder->expr()->eq('call_date', 0))
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->orderBy('cache_priority', 'desc')
+            ->executeQuery()
+            ->fetchAllAssociative();
     }
 
     /**
@@ -45,7 +65,9 @@ class QueueRepository extends AbstractRepository
 
     /**
      * Find old entries.
+     *
      * @return iterable<array{uid: int}>
+     * @throws Exception
      */
     public function findOldUids(): iterable
     {
@@ -57,6 +79,191 @@ class QueueRepository extends AbstractRepository
             ->executeQuery()
             ->iterateAssociative()
         ;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function findOldBatch(int $limit = 1000): array
+    {
+        $queryBuilder = $this->createQuery();
+
+        return $queryBuilder->select('uid')
+            ->from($this->getTableName())
+            ->where($queryBuilder->expr()->gt('call_date', 0))
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
+
+    /**
+     * Find existing identifiers (already in queue)
+     *
+     * @throws Exception
+     */
+    public function findExistingIdentifiers(array $identifiers): array
+    {
+        if (empty($identifiers)) {
+            return [];
+        }
+
+        $queryBuilder = $this->createQuery();
+        $result = $queryBuilder->select('cache_url')
+            ->from($this->getTableName())
+            ->where(
+                $queryBuilder->expr()->and(
+                    $queryBuilder->expr()->in(
+                        'cache_url',
+                        $queryBuilder->createNamedParameter($identifiers, ArrayParameterType::STRING)
+                    ),
+                    $queryBuilder->expr()->eq('call_date', 0)
+                )
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_column($result, 'cache_url');
+    }
+
+    /**
+     * Delete entries in batch
+     * @param array $uids List of UIDs to delete
+     * @return int Number of deleted records
+     */
+    public function bulkDelete(array $uids): int
+    {
+        if (empty($uids)) {
+            return 0;
+        }
+
+        $queryBuilder = $this->createQuery();
+        return $queryBuilder->delete($this->getTableName())
+            ->where(
+                $queryBuilder->expr()->in(
+                    'uid',
+                    $queryBuilder->createNamedParameter($uids, ArrayParameterType::INTEGER)
+                )
+            )
+            ->executeStatement();
+    }
+
+    /**
+     * Insert multiple records at once with optimized transaction handling
+     * @param array $records Array of record data to insert
+     * @return int Number of inserted records
+     * @throws Exception
+     */
+    public function bulkInsert(array $records): int
+    {
+        if (empty($records)) {
+            return 0;
+        }
+
+        $connection = $this->getConnection();
+        return $connection->bulkInsert(
+            $this->getTableName(),
+            $records,
+            ['cache_url', 'page_uid', 'invalid_date', 'call_result', 'cache_priority']
+        );
+    }
+
+    /**
+     * @param \Generator $recordsGenerator Generator that yields batches of records
+     * @param int $batchSize Recommended batch size (500-1000 for best performance)
+     * @return int Total number of inserted records
+     * @throws Exception
+     * @throws \Throwable
+     */
+    public function streamedBulkInsert(\Generator $recordsGenerator, int $batchSize = 1000): int
+    {
+        $connection = $this->getConnection();
+        $totalInserted = 0;
+        $recordBatch = [];
+
+        $connection->beginTransaction();
+        try {
+            foreach ($recordsGenerator as $record) {
+                $recordBatch[] = $record;
+
+                if (count($recordBatch) >= $batchSize) {
+                    $inserted = $connection->bulkInsert(
+                        $this->getTableName(),
+                        $recordBatch,
+                        ['cache_url', 'page_uid', 'invalid_date', 'call_result', 'cache_priority']
+                    );
+                    $totalInserted += $inserted;
+                    $recordBatch = [];
+                }
+            }
+
+            if (!empty($recordBatch)) {
+                $inserted = $connection->bulkInsert(
+                    $this->getTableName(),
+                    $recordBatch,
+                    ['cache_url', 'page_uid', 'invalid_date', 'call_result', 'cache_priority']
+                );
+                $totalInserted += $inserted;
+            }
+
+            $connection->commit();
+        } catch (\Throwable $e) {
+            $connection->rollBack();
+            throw $e;
+        }
+
+        return $totalInserted;
+    }
+
+    /**
+     * @throws Exception
+     * @throws \Throwable
+     */
+    public function bulkUpdate(array $records): int
+    {
+        if (empty($records)) {
+            return 0;
+        }
+
+        $connection = $this->getConnection();
+        $count = 0;
+
+        $connection->beginTransaction();
+        try {
+            foreach ($records as $record) {
+                if (!isset($record['uid'])) {
+                    continue;
+                }
+
+                $count += $connection->update(
+                    $this->getTableName(),
+                    [
+                        'call_date' => $record['call_date'],
+                        'call_result' => $record['call_result'],
+                    ],
+                    ['uid' => $record['uid']]
+                );
+            }
+
+            $connection->commit();
+        } catch (\Throwable $e) {
+            $connection->rollBack();
+            throw $e;
+        }
+
+        return $count;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function countOpen(): int
+    {
+        $queryBuilder = $this->createQuery();
+        return (int) $queryBuilder->count('uid')
+            ->from($this->getTableName())
+            ->where($queryBuilder->expr()->eq('call_date', 0))
+            ->executeQuery()
+            ->fetchOne();
     }
 
     protected function getTableName(): string

--- a/Classes/Service/ClientService.php
+++ b/Classes/Service/ClientService.php
@@ -8,6 +8,9 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -24,6 +27,78 @@ class ClientService implements LoggerAwareInterface
     public function __construct(protected EventDispatcherInterface $eventDispatcher) {}
 
     /**
+     * Run multiple requests in parallel and return status codes.
+     *
+     * @param array $urls List of URLs to process
+     * @param int $concurrency Number of concurrent requests
+     * @return array Status codes indexed same as input URLs
+     */
+    public function runMultipleRequests(array $urls, int $concurrency = 5): array
+    {
+        if (empty($urls)) {
+            return [];
+        }
+
+        $domains = [];
+        foreach ($urls as $url) {
+            $host = parse_url($url, PHP_URL_HOST);
+            if ($host) {
+                $domains[$url] = $host;
+            }
+        }
+
+        if (empty($domains)) {
+            return array_fill(0, count($urls), 900);
+        }
+
+        try {
+            $cookies = $this->prepareSessionCookies($domains);
+
+            $clients = array_map(fn($domain) => $this->getCallableClient($domain), $domains);
+
+            $requests = static function ($urls) use ($clients, $cookies) {
+                foreach ($urls as $url) {
+                    if (isset($clients[$url])) {
+                        yield new Request('GET', $url, [
+                            'cookies' => $cookies[parse_url((string) ($clients[$url]->getConfig('base_uri') ?? ''), PHP_URL_HOST)] ?? null,
+                            'User-Agent' => GeneralUtility::makeInstance(ConfigurationService::class)
+                                ->get('overrideClientUserAgent') ?? self::DEFAULT_USER_AGENT,
+                        ]);
+                    } else {
+                        yield new Request('GET', $url, [
+                            'User-Agent' => GeneralUtility::makeInstance(ConfigurationService::class)
+                                ->get('overrideClientUserAgent') ?? self::DEFAULT_USER_AGENT,
+                        ]);
+                    }
+                }
+            };
+
+            $statusCodes = array_fill(0, count($urls), 900);
+
+            $poolClient = $this->getParallelClient();
+
+            $pool = new Pool($poolClient, $requests($urls), [
+                'concurrency' => $concurrency,
+                'fulfilled' => static function (Response $response, $index) use (&$statusCodes): void {
+                    $statusCodes[$index] = (int) $response->getStatusCode();
+                },
+                'rejected' => function ($reason, $index) use (&$statusCodes): void {
+                    $this->logger->warning('Request failed: ' . ($reason instanceof \Exception ? $reason->getMessage() : 'Unknown error'));
+                    $statusCodes[$index] = 900;
+                },
+            ]);
+
+            $pool->promise()->wait();
+
+            return $statusCodes;
+
+        } catch (\Throwable $exception) {
+            $this->logger->error('Problems in batch request processing: ' . $exception->getMessage() . ' / ' . $exception->getFile() . ':' . $exception->getLine());
+            return array_fill(0, count($urls), 900);
+        }
+    }
+
+    /**
      * Run a single request with guzzle and return status code.
      */
     public function runSingleRequest(string $url): int
@@ -36,8 +111,8 @@ class ClientService implements LoggerAwareInterface
             $client = $this->getCallableClient($host);
             $response = $client->get($url);
 
-            return (int) $response->getStatusCode();
-        } catch (\Exception $exception) {
+            return $response->getStatusCode();
+        } catch (\Throwable $exception) {
             $this->logger->error('Problems in single request running: ' . $exception->getMessage() . ' / ' . $exception->getFile() . ':' . $exception->getLine());
         }
 
@@ -45,7 +120,7 @@ class ClientService implements LoggerAwareInterface
     }
 
     /**
-     * Get a cllable client.
+     * Get a callable client.
      *
      * @throws \Exception
      */
@@ -89,5 +164,68 @@ class ClientService implements LoggerAwareInterface
         ArrayUtility::mergeRecursiveWithOverrule($base, $event->getOptions());
 
         return GeneralUtility::makeInstance(Client::class, $base);
+    }
+
+    /**
+     * Get client optimized for parallel requests
+     */
+    protected function getParallelClient(): Client
+    {
+        $options = [
+            'timeout' => 30,
+            'connect_timeout' => 10,
+            'allow_redirects' => [
+                'max' => false,
+            ],
+        ];
+
+        $httpOptions = (array) $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
+        $httpOptions['verify'] = filter_var($httpOptions['verify'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $httpOptions['verify'];
+        if (isset($httpOptions['handler']) && \is_array($httpOptions['handler'])) {
+            $stack = HandlerStack::create();
+            foreach ($httpOptions['handler'] as $handler) {
+                $stack->push($handler);
+            }
+            $httpOptions['handler'] = $stack;
+        }
+
+        $event = new BuildClientEvent($options, $httpOptions);
+        $this->eventDispatcher->dispatch($event);
+
+        $base = $event->getHttpOptions();
+        ArrayUtility::mergeRecursiveWithOverrule($base, $event->getOptions());
+
+        return GeneralUtility::makeInstance(Client::class, $base);
+    }
+
+    /**
+     * Prepare session cookies for multiple domains
+     *
+     * @param array $domains Domain names indexed by URL
+     * @return array Cookie jars indexed by domain
+     */
+    protected function prepareSessionCookies(array $domains): array
+    {
+        $cookies = [];
+        $uniqueDomains = array_unique(array_values($domains));
+        $currentTime = (new DateTimeService())->getCurrentTime();
+
+        foreach ($uniqueDomains as $domain) {
+            $jar = GeneralUtility::makeInstance(CookieJar::class);
+
+            /** @var SetCookie $cookie */
+            $cookie = GeneralUtility::makeInstance(SetCookie::class);
+            $cookie->setName(CookieService::FE_COOKIE_NAME);
+            $cookie->setValue('1');
+            $cookie->setPath('/');
+            $cookie->setExpires($currentTime + 3600);
+            $cookie->setDomain($domain);
+            $cookie->setHttpOnly(true);
+
+            $jar->setCookie($cookie);
+            $cookies[$domain] = $jar;
+        }
+
+        return $cookies;
     }
 }

--- a/Classes/Service/QueueService.php
+++ b/Classes/Service/QueueService.php
@@ -20,6 +20,7 @@ class QueueService implements LoggerAwareInterface
     public const PRIORITY_HIGH = 2000;
     public const PRIORITY_MEDIUM = 1000;
     public const PRIORITY_LOW = 0;
+    public const BATCH_SIZE = 500;
 
     public function __construct(
         protected QueueRepository $queueRepository,
@@ -28,19 +29,38 @@ class QueueService implements LoggerAwareInterface
         protected CacheService $cacheService
     ) {}
 
-    /**
-     * Add identifiers to Queue.
-     */
     public function addIdentifiers(array $identifiers, int $overridePriority = self::PRIORITY_LOW): void
     {
-        foreach ($identifiers as $identifier) {
-            $this->addIdentifier($identifier, $overridePriority);
+        if (empty($identifiers)) {
+            return;
+        }
+
+        $existingIdentifiers = $this->queueRepository->findExistingIdentifiers($identifiers);
+        $filteredIdentifiers = array_diff($identifiers, $existingIdentifiers);
+
+        if (empty($filteredIdentifiers)) {
+            return;
+        }
+
+        $this->logger->debug('SFC Queue adding batch', ['count' => count($filteredIdentifiers)]);
+
+        $batches = array_chunk($filteredIdentifiers, self::BATCH_SIZE);
+        foreach ($batches as $batch) {
+            $insertData = [];
+            foreach ($batch as $identifier) {
+                $priority = $this->determinePriority($identifier, $overridePriority);
+                $insertData[] = [
+                    'cache_url' => $identifier,
+                    'page_uid' => 0,
+                    'invalid_date' => time(),
+                    'call_result' => '',
+                    'cache_priority' => $priority,
+                ];
+            }
+            $this->queueRepository->bulkInsert($insertData);
         }
     }
 
-    /**
-     * Add identifier to Queue.
-     */
     public function addIdentifier(string $identifier, int $overridePriority = self::PRIORITY_LOW): void
     {
         $count = $this->queueRepository->countOpenByIdentifier($identifier);
@@ -50,20 +70,7 @@ class QueueService implements LoggerAwareInterface
 
         $this->logger->debug('SFC Queue add', [$identifier]);
 
-        if ($overridePriority) {
-            $priority = $overridePriority;
-        } else {
-            $priority = self::PRIORITY_LOW;
-
-            try {
-                $cache = $this->cacheService->get();
-                $infos = $cache->get($identifier);
-                if (isset($infos['priority'])) {
-                    $priority = (int) $infos['priority'];
-                }
-            } catch (\Exception $exception) {
-            }
-        }
+        $priority = $this->determinePriority($identifier, $overridePriority);
 
         $data = [
             'cache_url' => $identifier,
@@ -74,6 +81,80 @@ class QueueService implements LoggerAwareInterface
         ];
 
         $this->queueRepository->insert($data);
+    }
+
+    protected function determinePriority(string $identifier, int $overridePriority): int
+    {
+        if ($overridePriority) {
+            return $overridePriority;
+        }
+
+        $priority = self::PRIORITY_LOW;
+        try {
+            $cache = $this->cacheService->get();
+            $infos = $cache->get($identifier);
+            if (isset($infos['priority'])) {
+                $priority = (int) $infos['priority'];
+            }
+        } catch (\Throwable) {
+            // Ignore
+        }
+
+        return $priority;
+    }
+
+    /**
+     * @throws NoSuchCacheException
+     * @throws \Exception
+     * @throws \Throwable
+     */
+    public function runBatchRequests(array $runEntries, int $maxParallel = 10): array
+    {
+        if (empty($runEntries)) {
+            return [];
+        }
+
+        $this->configurationService->override('boostMode', '0');
+        $cache = $this->cacheService->get();
+        $statusResults = [];
+
+        $chunks = array_chunk($runEntries, $maxParallel);
+        foreach ($chunks as $chunk) {
+            foreach ($chunk as $runEntry) {
+                if ($cache->has($runEntry['cache_url'])) {
+                    $cache->remove($runEntry['cache_url']);
+                }
+            }
+
+            $this->logger->debug('SFC Queue batch run', ['count' => count($chunk)]);
+
+            $statusCodes = $this->clientService->runMultipleRequests(
+                array_column($chunk, 'cache_url')
+            );
+
+            $batchResults = [];
+            foreach ($chunk as $index => $runEntry) {
+                $statusCode = $statusCodes[$index] ?? 0;
+                $statusResults[] = $statusCode;
+
+                $batchResults[] = [
+                    'uid' => (int) $runEntry['uid'],
+                    'call_date' => time(),
+                    'call_result' => $statusCode,
+                    'page_uid' => $runEntry['page_uid'],
+                ];
+
+                if (200 !== $statusCode && $runEntry['page_uid'] > 0) {
+                    // Call the flush if the page is not accessible
+                    $cache->flushByTag('pageId_' . $runEntry['page_uid']);
+                }
+            }
+
+            $this->queueRepository->bulkUpdate($batchResults);
+        }
+
+        $this->configurationService->reset('boostMode');
+        return $statusResults;
     }
 
     /**
@@ -100,7 +181,7 @@ class QueueService implements LoggerAwareInterface
         ];
 
         if (200 !== $statusCode) {
-            // Call the flush, if the page is not accessable
+            // Call the flush, if the page is not accessible
             $cache->flushByTag('pageId_' . $runEntry['page_uid']);
         }
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -20,5 +20,7 @@ CREATE TABLE tx_staticfilecache_queue (
 	call_date int(11) DEFAULT '0' NOT NULL,
 	call_result varchar(255) NOT NULL,
 	PRIMARY KEY (uid),
-	INDEX call_date (call_date, cache_url(100))
+	INDEX call_date (call_date, cache_url(100)),
+	INDEX cache_url (cache_url(255)),
+	INDEX cache_priority (cache_priority)
 );


### PR DESCRIPTION
Short description
-----------------

Improves the performance of boost mode cache flush and crawling to refill the cache.

Cache flush (80.000 entries in cache), before:
```sh
time ./vendor/bin/typo3 staticfilecache:flushCache

real    2m51.869s
user    0m19.032s
sys     0m15.217s
```

and after:
```sh
time ./vendor/bin/typo3 staticfilecache:flushCache

real    0m35.927s
user    0m6.952s
sys     0m6.502s
```

It's 5x (!) faster than before.

Crawling to refill the cache is also improved, but the numbers are not that massive.

Related Issue
-------------

Fixes #435 

More Details
------------

Please review and test to give me feedback. I am willing to adapt things.
