### PR TITLE
Fix FallbackMiddleware.php accept-encoding header

### DIFF
--- a/Classes/Middleware/FallbackMiddleware.php
+++ b/Classes/Middleware/FallbackMiddleware.php
@@ -103,17 +103,15 @@ class FallbackMiddleware implements MiddlewareInterface
                 if (is_file($possibleStaticFile . '.br') && is_readable($possibleStaticFile . '.br')) {
                     $headers['Content-Encoding'] = 'br';
                     $possibleStaticFile .= '.br';
+                    break;
                 }
-
-                break;
             }
             if (str_contains($acceptEncoding, 'gzip')) {
                 if (is_file($possibleStaticFile . '.gz') && is_readable($possibleStaticFile . '.gz')) {
                     $headers['Content-Encoding'] = 'gzip';
                     $possibleStaticFile .= '.gz';
+                    break;
                 }
-
-                break;
             }
         }
 


### PR DESCRIPTION
Short description
-----------------
The FallbackMiddleware does not correctly handle the encoding type of the cache-file. The "break" statement should be moved inside the if. If the cache file are encoding using gzip, the correct file extension would never be added otherwise.
...

Related Issue
-------------

...

More Details
------------

- Work in Progress?
- Open Issues?
