### PR TITLE
[BUGFIX] Don't cache pages during solr indexing

### DIFF
--- a/Classes/Cache/Listener/SolrIndexingProcessListener.php
+++ b/Classes/Cache/Listener/SolrIndexingProcessListener.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace SFC\Staticfilecache\Cache\Listener;
 
-use SFC\Staticfilecache\Event\CacheRuleFallbackEvent;
+use SFC\Staticfilecache\Event\CacheRuleEventInterface;
 
 /**
  * Solr Indexing process.
  */
 class SolrIndexingProcessListener
 {
-    public function __invoke(CacheRuleFallbackEvent $event): void
+    public function __invoke(CacheRuleEventInterface $event): void
     {
-        if ($event->getRequest()->hasHeader('X-Tx-Solr-Iq')) {
+        if ($event->getRequest()->getAttribute('solr.indexingInstructions', null) !== null) {
             $event->addExplanation(__CLASS__, 'Solr Indexing request');
             $event->setSkipProcessing(true);
         }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -58,6 +58,9 @@ services:
       - name: event.listener
         identifier: 'SolrIndexingProcessListenerFallback'
         event: SFC\Staticfilecache\Event\CacheRuleFallbackEvent
+      - name: event.listener
+        identifier: 'SolrIndexingProcessListener'
+        event: SFC\Staticfilecache\Event\CacheRuleEvent
 
   SFC\Staticfilecache\Cache\Listener\T3CrawlerIndexingProcessListener:
     tags:


### PR DESCRIPTION
In EXT:solr version 14, indexing requests are
executed via subrequests instead of HTTP/HTTPS.

Additionally, query parameters were moved
to a custom request attribute
`solr.indexingInstructions`,
which still allows identifying indexing requests.

Due to the change to subrequests, it seems
necessary to also trigger the
`SolrIndexingProcessListener` with the
CacheRuleEvent (PrepareMiddleware).

Resolves: #464

Short description
-----------------

...

Related Issue
-------------

...

More Details
------------

- Work in Progress?
- Open Issues?
